### PR TITLE
Add cats-helper-testkit module

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,20 @@ This is useful to ensure `release` called at most once, in cases when "unsafe" a
 val resource: Resource[F, A] = ???
 resource.fenced
 ```
- 
+
+## PureTest
+
+This helper lives in a separate `cats-helper-testkit` module. It is makes testing `F[_]`-based code easier.
+
+```scala
+"what time is it now?" in PureTest[IO].of { env =>
+  import env._
+  for {
+    _ <- IO.sleep(1.hour)
+    _ <- testRuntime.getTimeSinceStart.map(_ shouldBe 1.hour)
+  } yield ()
+}
+```
 
 ## Setup
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,9 @@ lazy val core = project
       scalatest % Test,
     ),
   )
+  .dependsOn(
+    testkit % Test,
+  )
 
 lazy val testkit = project
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,8 @@ inThisBuild(Seq(
   releaseCrossBuild := true,
 
   resolvers += Resolver.bintrayRepo("evolutiongaming", "maven"),
+
+  addCompilerPlugin(cpKindProjector),
 ))
 
 lazy val root = project
@@ -25,6 +27,7 @@ lazy val root = project
   )
   .aggregate(
     core,
+    testkit,
   )
 
 lazy val core = project
@@ -40,5 +43,15 @@ lazy val core = project
       machinist,
       `slf4j-api`,
       scalatest % Test,
+    ),
+  )
+
+lazy val testkit = project
+  .settings(
+    name := "cats-helper-testkit",
+
+    libraryDependencies ++= Seq(
+      Cats.effectLaws,
+      scalatest,
     ),
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,11 +6,16 @@ object Dependencies {
   val machinist   = "org.typelevel"     %% "machinist" % "0.6.8"
   val `slf4j-api` = "org.slf4j"          % "slf4j-api" % "1.7.30"
 
+  val cpKindProjector = "org.typelevel" % "kind-projector" % "0.11.0" cross CrossVersion.full
+
   object Cats {
     private val version = "2.0.0"
     val core   = "org.typelevel" %% "cats-core"   % version
     val kernel = "org.typelevel" %% "cats-kernel" % version
     val macros = "org.typelevel" %% "cats-macros" % version
-    val effect = "org.typelevel" %% "cats-effect" % "2.0.0"
+
+    private val effectVersion = "2.0.0"
+    val effect     = "org.typelevel" %% "cats-effect"      % effectVersion
+    val effectLaws = "org.typelevel" %% "cats-effect-laws" % effectVersion
   }
 }

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/PureTest.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/PureTest.scala
@@ -1,0 +1,159 @@
+package com.evolutiongaming.catshelper.testkit
+
+import cats.effect.implicits._
+import cats.effect.laws.util.TestContext
+import cats.effect.{Async, ContextShift, Effect, IO, LiftIO, Sync, Timer}
+import cats.implicits._
+import cats.{Id, ~>}
+import org.scalatest.exceptions.{TestCanceledException, TestFailedException}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+
+/**
+ * Provides a boilerplate for writing "pure FP" tests (usually using `IO` and for-comprehensions).
+ *
+ * Time in tests is simulated. Clocks "move" only with time-based actions (such as `IO.sleep(…)`)
+ * while anything else is perceived to happen "immediately". Corollary:
+ *  - you can use `IO.sleep` with arbitrary delays to test concurrent behaviour, scheduling, etc.
+ *  - no matter how long are the durations in your test, the test itself runs as fast as possible.
+ *
+ * Another virtue of `PureTest` is that can terminate "hot loops" that do infinite monadic binds,
+ * e.g. `IO.unit.foreverM`. It does this by cancelling the running test after a "wall-clock" delay.
+ * This may introduce test flakiness for long CPU-intensive scenarios, when your hardware is stressed,
+ * but for such cases you have control over the hot loop cancellation timeout.
+ *
+ * Keep in mind though, that hot loop detector is not a silver bullet. It can't help against
+ * `while (true)`, neither against infinite binds in `uncancelable` regions.
+ *
+ * @example {{{
+ *   "what time is it now?" in PureTest[IO].of { env =>
+ *     import env._
+ *     for {
+ *       _ <- IO.sleep(1.hour)
+ *       _ <- testRuntime.getTimeSinceStart.map(_ shouldBe 1.hour)
+ *     } yield ()
+ *   }
+ * }}}
+ */
+object PureTest {
+  /** An environment that is injected into every test. */
+  trait Env[F[_]] {
+    implicit def ec: ExecutionContext
+    implicit def cs: ContextShift[F]
+    implicit def timer: Timer[F]
+    implicit def testRuntime: TestRuntime[F]
+  }
+
+  type TestBody[F[_], A] = Env[F] => F[A]
+  type RunTest[F[_]] = TestBody[F, *] ~> Id
+
+  /**
+   * First step of building your test.
+   *
+   * @see [[PartialApply the rest of the builder]]
+   * @see [[ioTest:* `ioTest`]] – a shortcut for `IO`-based tests.
+   */
+  def apply[F[_] : Effect]: PartialApply[F] = new PartialApply[F]
+
+  /** A follow-up to [[apply `PureTest[F]`]]. */
+  final class PartialApply[F[_] : Effect] {
+    /** Builds and runs the test with default settings. */
+    def of: RunTest[F] = of(defaultHotLoopTimeout)
+
+    /**
+     * Builds and runs the test. You may customise its settings.
+     *
+     * @param hotLoopTimeout – a time it takes to decide that test is spinning in a hot loop and kill it.
+     */
+    def of(hotLoopTimeout: FiniteDuration = defaultHotLoopTimeout): RunTest[F] =
+      Lambda[TestBody[F, *] ~> Id](body => runTest(body, hotLoopTimeout))
+  }
+
+  /** A shorter version of [[PartialApply.of:* `PureTest[IO].of`]]. */
+  def ioTest: RunTest[IO] = PureTest[IO].of
+
+  /** A shorter version of [[PartialApply.of(* `PureTest[IO].of(…)`]]. */
+  def ioTest(hotLoopTimeout: FiniteDuration = defaultHotLoopTimeout): RunTest[IO] =
+    PureTest[IO].of(hotLoopTimeout)
+
+  /** A default timeout for hot loop detection. */
+  def defaultHotLoopTimeout: FiniteDuration = 10.seconds
+
+  private def runTest[F[_] : Effect, A](body: TestBody[F, A], hotLoopTimeout: FiniteDuration) = {
+    val testControl = new TestControl(
+      hotLoopGuard = IO.timer(ExecutionContext.global).sleep(hotLoopTimeout),
+    )
+    val testIO = wrap(body, testControl)
+    testIO.unsafeRunSync()
+  }
+
+  private def wrap[F[_] : Effect, A](body: TestBody[F, A], testControl: TestControl): IO[A] = IO.suspend {
+    val env = new EnvImpl[F]
+
+    val testIo = (env.cs.shift *> body(env)).toIO
+
+    @volatile var outcome: Option[Either[Throwable, A]] = None
+    val cancel = testIo.unsafeRunCancelable { r => outcome = Some(r) }
+
+    val testThread = Thread.currentThread()
+
+    val stopHotLoop = IO.suspend {
+      val err = new IllegalStateException("Still running")
+      err.setStackTrace(testThread.getStackTrace)
+      outcome = Some(Left(err))
+      cancel
+    }
+
+    val timeoutCancel = (testControl.hotLoopGuard *> stopHotLoop).unsafeRunCancelable(_ => ())
+
+    while (outcome.isEmpty && env.testContext.state.tasks.nonEmpty) {
+      val step = env.testContext.state.tasks.iterator.map(_.runsAt).min
+      env.testContext.tick(step)
+    }
+
+    timeoutCancel.unsafeRunSync()
+
+    testControl.completeWith(outcome, env.testContext.state)
+  }
+
+  private class EnvImpl[F[_] : Async : LiftIO] extends Env[F] {
+    val testContext: TestContext = TestContext()
+
+    implicit def ec: ExecutionContext = testContext
+    implicit val cs: ContextShift[F] = testContext.contextShift[F]
+    implicit val timer: Timer[F] = testContext.timer[F]
+
+    implicit val testRuntime: TestRuntime[F] = new TestRuntime[F] {
+
+      /** NB: We exploit the fact that TestContext starts from 0. */
+      def getTimeSinceStart: F[FiniteDuration] = Sync[F].delay(testContext.state.clock)
+    }
+  }
+
+  private class TestControl(val hotLoopGuard: IO[Unit]) {
+    def completeWith[A](outcome: Option[Either[Throwable, A]], tcState: TestContext.State): IO[A] = IO {
+      def boo(cause: Either[Throwable, String]): Nothing = {
+        val err = cause match {
+          case Left(e: TestFailedException)   => e
+          case Left(e: TestCanceledException) => e
+          case abnormal                       => AbnormalTermination(abnormal, tcState)
+        }
+        throw err
+      }
+
+      outcome match {
+        case Some(Right(a)) => a
+        case Some(Left(e))  => boo(Left(e))
+        case None           => boo(Right(s"Not completed. State: $tcState"))
+      }
+    }
+  }
+
+  final case class AbnormalTermination(
+    cause: Either[Throwable, String],
+    tcState: TestContext.State,
+  ) extends RuntimeException(s"${ cause.fold(_.toString, identity) }. $tcState", cause.left.toOption.orNull)
+    with NoStackTrace
+}

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/TestRuntime.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/TestRuntime.scala
@@ -1,0 +1,14 @@
+package com.evolutiongaming.catshelper.testkit
+
+import scala.concurrent.duration.FiniteDuration
+
+/**
+ * Provides access to running test info.
+ */
+trait TestRuntime[F[_]] {
+  def getTimeSinceStart: F[FiniteDuration]
+}
+
+object TestRuntime {
+  def apply[F[_]](implicit summonned: TestRuntime[F]): TestRuntime[F] = summonned
+}

--- a/testkit/src/test/scala/com/evolutiongaming/catshelper/testkit/PureTestSpec.scala
+++ b/testkit/src/test/scala/com/evolutiongaming/catshelper/testkit/PureTestSpec.scala
@@ -1,0 +1,45 @@
+package com.evolutiongaming.catshelper.testkit
+
+import cats.effect.IO
+import cats.implicits._
+import com.evolutiongaming.catshelper.testkit.PureTest.{AbnormalTermination, ioTest}
+import org.scalatest.exceptions.TestFailedException
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers._
+
+import scala.concurrent.duration._
+
+class PureTestSpec extends AnyFreeSpec {
+  "time flows as expected" in ioTest { env =>
+    import env._
+    for {
+      _ <- IO.race(IO.sleep(1.hour), IO.sleep(1.day))
+      _ <- testRuntime.getTimeSinceStart.map(_ shouldBe 1.hour)
+    } yield ()
+  }
+
+  "false assertion fails a test" in {
+    assertThrows[TestFailedException] {
+      ioTest { _ => IO { 1 shouldBe 2 } }
+    }
+  }
+
+  "non-termination fails a test" in {
+    assertThrows[AbnormalTermination] {
+      ioTest { _ => IO.never }
+    }
+  }
+
+  "hot loop fails a test" in {
+    assertThrows[AbnormalTermination] {
+      ioTest(hotLoopTimeout = 100.millis) { _ => IO.unit.foreverM }
+    }
+  }
+
+  "is unaffected by infinite background loops" in ioTest { env =>
+    import env._
+    val main = IO.sleep(1.milli)
+    val loop = IO.sleep(1.nano).foreverM
+    loop.start *> main
+  }
+}


### PR DESCRIPTION
This PR introduces new module `cats-helper-testkit`. This module provides `PureTest` utility that makes it easier to write `F[_]`-based tests.
