### PR TITLE
Restructure PureTest, add more options, make ScalaTest optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ ftService.use { access =>
 
 This helper lives in a separate `cats-helper-testkit` module. It is makes testing `F[_]`-based code easier.
 
+**NOTE:** `cats-helper-testkit` is an experimental module and may break SemVer guarantees from time to time.
+However we will do our best to avoid unnecessary breakages.
+
 ```scala
 "what time is it now?" in PureTest[IO].of { env =>
   import env._

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,6 @@ lazy val testkit = project
 
     libraryDependencies ++= Seq(
       Cats.effectLaws,
-      scalatest,
+      scalatest % Optional,
     ),
   )

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.catshelper
 
 import cats.effect.concurrent.{MVar, Ref}
-import cats.effect.{IO, Resource, Timer}
+import cats.effect.{IO, Resource}
 import cats.implicits._
 import com.evolutiongaming.catshelper.testkit.PureTest.ioTest
 import com.evolutiongaming.catshelper.testkit.{PureTest, TestRuntime}
@@ -153,6 +153,5 @@ class FeatureToggledSpec extends AnyFreeSpec {
 
   private def getTime(implicit rt: TestRuntime[IO]) = rt.getTimeSinceStart
 
-  private def sleepUntil(t1: FiniteDuration)(implicit t: Timer[IO], rt: TestRuntime[IO]) =
-    rt.getTimeSinceStart.flatMap(t0 => IO.sleep(t1 - t0))
+  private def sleepUntil(dt: FiniteDuration)(implicit rt: TestRuntime[IO]) = rt.sleepUntil(dt)
 }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ReadWriteRefSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ReadWriteRefSpec.scala
@@ -94,7 +94,7 @@ class ReadWriteRefSpec extends AnyFreeSpec {
     def getTime: IO[FiniteDuration] = testRuntime.getTimeSinceStart
   }
 
-  private def scope[A](body: Scope => IO[A]): A = PureTest.ioTest.apply[A] { env =>
+  private def scope[A](body: Scope => IO[A]): A = PureTest.ioTest { env =>
     import env._
     for {
       rw <- ReadWriteRef[IO].of(0)

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/AbnormalTermination.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/AbnormalTermination.scala
@@ -1,0 +1,11 @@
+package com.evolutiongaming.catshelper.testkit
+
+import cats.effect.laws.util.TestContext
+
+import scala.util.control.NoStackTrace
+
+final case class AbnormalTermination(
+  cause: Either[Throwable, String],
+  tcState: TestContext.State,
+) extends RuntimeException(s"${ cause.fold(_.toString, identity) }. $tcState", cause.left.toOption.orNull)
+  with NoStackTrace

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/PureTest.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/PureTest.scala
@@ -50,7 +50,7 @@ object PureTest extends PureTest {
   }
 
   private[testkit] case class Config(
-    testFrameworkApi: TestFrameworkApi = ScalaTestApi,
+    testFrameworkApi: TestFrameworkApi = TestFrameworkApi.resolveDefault,
     backgroundEc: ExecutionContext = ExecutionContext.global,
     hotLoopTimeout: FiniteDuration = 10.seconds,
     flakinessCheckIterations: Int = 1,

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/PureTest.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/PureTest.scala
@@ -1,15 +1,9 @@
 package com.evolutiongaming.catshelper.testkit
 
-import cats.effect.implicits._
-import cats.effect.laws.util.TestContext
-import cats.effect.{Async, ContextShift, Effect, IO, LiftIO, Sync, Timer}
-import cats.implicits._
-import cats.{Id, ~>}
-import org.scalatest.exceptions.{TestCanceledException, TestFailedException}
+import cats.effect.{ContextShift, Effect, IO, Timer}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
-import scala.util.control.NoStackTrace
 
 /**
  * Provides a boilerplate for writing "pure FP" tests (usually using `IO` and for-comprehensions).
@@ -37,7 +31,7 @@ import scala.util.control.NoStackTrace
  *   }
  * }}}
  */
-object PureTest {
+object PureTest extends PureTest {
   /** An environment that is injected into every test. */
   trait Env[F[_]] {
     implicit def ec: ExecutionContext
@@ -46,114 +40,73 @@ object PureTest {
     implicit def testRuntime: TestRuntime[F]
   }
 
-  type TestBody[F[_], A] = Env[F] => F[A]
-  type RunTest[F[_]] = TestBody[F, *] ~> Id
+  private val default: PureTest = Impl(Config())
+
+  protected def config = default.config
+  protected def withConfigMod(f: Config => Config) = default.withConfigMod(f)
+
+  private case class Impl(config: Config) extends PureTest {
+    protected def withConfigMod(f: Config => Config) = copy(f(config))
+  }
+
+  private[testkit] case class Config(
+    testFrameworkApi: TestFrameworkApi = ScalaTestApi,
+    backgroundEc: ExecutionContext = ExecutionContext.global,
+    hotLoopTimeout: FiniteDuration = 10.seconds,
+    flakinessCheckIterations: Int = 1,
+  )
+}
+
+/**
+ * Holds a test configuration. May be configured further or used to build and run a test.
+ */
+sealed trait PureTest { self =>
+  import PureTest._
 
   /**
-   * First step of building your test.
-   *
-   * @see [[PartialApply the rest of the builder]]
-   * @see [[ioTest:* `ioTest`]] – a shortcut for `IO`-based tests.
+   * A follow-up to [[apply `PureTest[F]`]].
    */
-  def apply[F[_] : Effect]: PartialApply[F] = new PartialApply[F]
-
-  /** A follow-up to [[apply `PureTest[F]`]]. */
-  final class PartialApply[F[_] : Effect] {
-    /** Builds and runs the test with default settings. */
-    def of: RunTest[F] = of(defaultHotLoopTimeout)
-
+  final class PartialApply[F[_]: Effect] {
     /**
-     * Builds and runs the test. You may customise its settings.
-     *
-     * @param hotLoopTimeout – a time it takes to decide that test is spinning in a hot loop and kill it.
+     * Builds and runs the test with previously defined settings.
      */
-    def of(hotLoopTimeout: FiniteDuration = defaultHotLoopTimeout): RunTest[F] =
-      Lambda[TestBody[F, *] ~> Id](body => runTest(body, hotLoopTimeout))
+    def of[A](body: Env[F] => F[A]): A = PureTestRunner.doRunTest(body, config)
   }
 
-  /** A shorter version of [[PartialApply.of:* `PureTest[IO].of`]]. */
-  def ioTest: RunTest[IO] = PureTest[IO].of
+  /**
+   * A first half of [[PartialApply.of `PureTest[F].of`]].
+   *
+   * @see [[ioTest `ioTest`]] – a shortcut for `IO`-based tests.
+   */
+  final def apply[F[_]: Effect]: PartialApply[F] = new PartialApply[F]
 
-  /** A shorter version of [[PartialApply.of(* `PureTest[IO].of(…)`]]. */
-  def ioTest(hotLoopTimeout: FiniteDuration = defaultHotLoopTimeout): RunTest[IO] =
-    PureTest[IO].of(hotLoopTimeout)
+  /**
+   * A shorter version of [[PartialApply.of `PureTest[IO].of`]].
+   */
+  final def ioTest[A](body: Env[IO] => IO[A]): A = PureTestRunner.doRunTest(body, config)
 
-  /** A default timeout for hot loop detection. */
-  def defaultHotLoopTimeout: FiniteDuration = 10.seconds
+  protected def config: Config
 
-  private def runTest[F[_] : Effect, A](body: TestBody[F, A], hotLoopTimeout: FiniteDuration) = {
-    val testControl = new TestControl(
-      hotLoopGuard = IO.timer(ExecutionContext.global).sleep(hotLoopTimeout),
-    )
-    val testIO = wrap(body, testControl)
-    testIO.unsafeRunSync()
-  }
+  protected def withConfigMod(f: Config => Config): PureTest
 
-  private def wrap[F[_] : Effect, A](body: TestBody[F, A], testControl: TestControl): IO[A] = IO.suspend {
-    val env = new EnvImpl[F]
+  /**
+   * Sets a test-framework integration layer. Currently defaults to ScalaTest.
+   */
+  final def testFrameworkApi(v: TestFrameworkApi): PureTest = withConfigMod(_.copy(testFrameworkApi = v))
 
-    val testIo = (env.cs.shift *> body(env)).toIO
+  /**
+   * Sets hot-loop detection timeout. Use it CPU-bound part of your SUT or test requires longer time.
+   */
+  final def hotLoopTimeout(v: FiniteDuration): PureTest = withConfigMod(_.copy(hotLoopTimeout = v))
 
-    @volatile var outcome: Option[Either[Throwable, A]] = None
-    val cancel = testIo.unsafeRunCancelable { r => outcome = Some(r) }
+  /**
+   * Sets an `ExecutionContext` used for background tasks, such as hot loop detection.
+   * Defaults to `ExecutionContext.global`.
+   */
+  final def backgroundEc(v: ExecutionContext): PureTest = withConfigMod(_.copy(backgroundEc = v))
 
-    val testThread = Thread.currentThread()
-
-    val stopHotLoop = IO.suspend {
-      val err = new IllegalStateException("Still running")
-      err.setStackTrace(testThread.getStackTrace)
-      outcome = Some(Left(err))
-      cancel
-    }
-
-    val timeoutCancel = (testControl.hotLoopGuard *> stopHotLoop).unsafeRunCancelable(_ => ())
-
-    while (outcome.isEmpty && env.testContext.state.tasks.nonEmpty) {
-      val step = env.testContext.state.tasks.iterator.map(_.runsAt).min
-      env.testContext.tick(step)
-    }
-
-    timeoutCancel.unsafeRunSync()
-
-    testControl.completeWith(outcome, env.testContext.state)
-  }
-
-  private class EnvImpl[F[_] : Async : LiftIO] extends Env[F] {
-    val testContext: TestContext = TestContext()
-
-    implicit def ec: ExecutionContext = testContext
-    implicit val cs: ContextShift[F] = testContext.contextShift[F]
-    implicit val timer: Timer[F] = testContext.timer[F]
-
-    implicit val testRuntime: TestRuntime[F] = new TestRuntime[F] {
-
-      /** NB: We exploit the fact that TestContext starts from 0. */
-      def getTimeSinceStart: F[FiniteDuration] = Sync[F].delay(testContext.state.clock)
-    }
-  }
-
-  private class TestControl(val hotLoopGuard: IO[Unit]) {
-    def completeWith[A](outcome: Option[Either[Throwable, A]], tcState: TestContext.State): IO[A] = IO {
-      def boo(cause: Either[Throwable, String]): Nothing = {
-        val err = cause match {
-          case Left(e: TestFailedException)   => e
-          case Left(e: TestCanceledException) => e
-          case abnormal                       => AbnormalTermination(abnormal, tcState)
-        }
-        throw err
-      }
-
-      outcome match {
-        case Some(Right(a)) => a
-        case Some(Left(e))  => boo(Left(e))
-        case None           => boo(Right(s"Not completed. State: $tcState"))
-      }
-    }
-  }
-
-  final case class AbnormalTermination(
-    cause: Either[Throwable, String],
-    tcState: TestContext.State,
-  ) extends RuntimeException(s"${ cause.fold(_.toString, identity) }. $tcState", cause.left.toOption.orNull)
-    with NoStackTrace
+  /**
+   * Sets a number of times to run a test to make sure it's not flaky. Defaults to `1`.
+   */
+  final def flakinessCheckIterations(v: Int): PureTest = withConfigMod(_.copy(flakinessCheckIterations = v))
 }

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/PureTestRunner.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/PureTestRunner.scala
@@ -1,0 +1,74 @@
+package com.evolutiongaming.catshelper.testkit
+
+import cats.effect.laws.util.TestContext
+import cats.effect.{Async, ContextShift, Effect, IO, LiftIO, Sync, Timer}
+import cats.effect.implicits._
+import cats.implicits._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+private[testkit] object PureTestRunner {
+  type TestBody[F[A], A] = PureTest.Env[F] => F[A]
+
+  def doRunTest[F[_] : Effect, A](body: TestBody[F, A], config: PureTest.Config) = {
+    val singleRun = wrap(body, config)
+
+    val fullTestIO = config.flakinessCheckIterations match {
+      case n if n > 0 => singleRun.replicateA(n).map(_.head)
+      case _          => singleRun
+    }
+
+    fullTestIO.unsafeRunSync()
+  }
+
+  private def wrap[F[_] : Effect, A](body: TestBody[F, A], config: PureTest.Config): IO[A] = IO.suspend {
+    val env = new EnvImpl[F]
+
+    val testIo = (env.cs.shift *> body(env)).toIO
+
+    @volatile var outcome: Option[Either[Throwable, A]] = None
+    val cancel = testIo.unsafeRunCancelable { r => outcome = Some(r) }
+
+    val testThread = Thread.currentThread()
+
+    val stopHotLoop = IO.suspend {
+      val err = new IllegalStateException("Still running")
+      err.setStackTrace(testThread.getStackTrace)
+      outcome = Some(Left(err))
+      cancel
+    }
+
+    val hotLoopGuard = IO.timer(config.backgroundEc).sleep(config.hotLoopTimeout)
+
+    val timeoutCancel = (hotLoopGuard *> stopHotLoop).unsafeRunCancelable(_ => ())
+
+    while (outcome.isEmpty && env.testContext.state.tasks.nonEmpty) {
+      val step = env.testContext.state.tasks.iterator.map(_.runsAt).min
+      env.testContext.tick(step)
+    }
+
+    timeoutCancel.unsafeRunSync()
+
+    config.testFrameworkApi.completeWith(outcome, env.testContext.state)
+  }
+
+  private class EnvImpl[F[_] : Async : LiftIO] extends PureTest.Env[F] {
+    val testContext: TestContext = TestContext()
+
+    implicit def ec: ExecutionContext = testContext
+    implicit val cs: ContextShift[F] = testContext.contextShift[F]
+    implicit val timer: Timer[F] = testContext.timer[F]
+
+    implicit val testRuntime: TestRuntime[F] = new TestRuntime[F] {
+
+      /** NB: We exploit the fact that TestContext starts from 0. */
+      def getTimeSinceStart: F[FiniteDuration] = Sync[F].delay(testContext.state.clock)
+
+      def sleepUntil(dt: FiniteDuration): F[Unit] =
+        getTimeSinceStart.flatMap(t => timer.sleep(dt - t).whenA(dt > t))
+    }
+  }
+}
+
+

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/TestFrameworkApi.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/TestFrameworkApi.scala
@@ -2,6 +2,7 @@ package com.evolutiongaming.catshelper.testkit
 
 import cats.effect.IO
 import cats.effect.laws.util.TestContext
+import cats.implicits._
 import org.scalatest.exceptions.{TestCanceledException, TestFailedException}
 
 /**
@@ -17,7 +18,46 @@ trait TestFrameworkApi {
   def completeWith[A](outcome: Option[Either[Throwable, A]], tcState: TestContext.State): IO[A]
 }
 
-object ScalaTestApi extends TestFrameworkApi {
+object TestFrameworkApi {
+  /**
+   * Returns either a default API (ScalaTest as of now) if it's available on the classpath.
+   * Uses [[NoFrameworkApi]] as a fallback.
+   */
+  def resolveDefault(implicit l: Lookup): TestFrameworkApi = l.instance
+
+  private[testkit] trait Lookup {
+    def instance: TestFrameworkApi
+  }
+
+  private[testkit] object Lookup extends LookupLowPriority {
+    implicit def scalaTestIsDefault(implicit ev: TestFailedException =:= TestFailedException): Lookup = {
+      if (ev == null) () else ()  // A kludge to avoid "unused" warning :(
+      new Lookup {
+        def instance: TestFrameworkApi = ScalaTestApi
+      }
+    }
+  }
+
+  private[testkit] sealed trait LookupLowPriority {
+    implicit def fallbackToNoFramework: Lookup = new Lookup {
+      def instance: TestFrameworkApi = NoFrameworkApi
+    }
+  }
+}
+
+/**
+ * A stub implementation to use when no test framework is available.
+ */
+object NoFrameworkApi extends TestFrameworkApi {
+  def completeWith[A](outcome: Option[Either[Throwable, A]], tcState: TestContext.State): IO[A] = {
+    IO.fromEither(outcome.toRight(new IllegalStateException(s"Not completed. State: $tcState")).flatten)
+  }
+}
+
+/**
+ * ScalaTest integration.
+ */
+private[testkit] object ScalaTestApi extends TestFrameworkApi {
   def completeWith[A](outcome: Option[Either[Throwable, A]], tcState: TestContext.State): IO[A] = IO {
     def boo(cause: Either[Throwable, String]): Nothing = {
       val err = cause match {
@@ -31,7 +71,7 @@ object ScalaTestApi extends TestFrameworkApi {
     outcome match {
       case Some(Right(a)) => a
       case Some(Left(e))  => boo(Left(e))
-      case None           => boo(Right(s"Not completed. State: $tcState"))
+      case None           => boo(Right("Not completed"))
     }
   }
 }

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/TestFrameworkApi.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/TestFrameworkApi.scala
@@ -1,0 +1,37 @@
+package com.evolutiongaming.catshelper.testkit
+
+import cats.effect.IO
+import cats.effect.laws.util.TestContext
+import org.scalatest.exceptions.{TestCanceledException, TestFailedException}
+
+/**
+ * EXPERIMENTAL. Abstracts interactions with a test framework.
+ */
+trait TestFrameworkApi {
+  /**
+   * Signals a completion of a test.
+   *
+   * @param outcome an outcome which can be non-termination, failure, or success.
+   * @param tcState `TestContext` state at the moment of completion.
+   */
+  def completeWith[A](outcome: Option[Either[Throwable, A]], tcState: TestContext.State): IO[A]
+}
+
+object ScalaTestApi extends TestFrameworkApi {
+  def completeWith[A](outcome: Option[Either[Throwable, A]], tcState: TestContext.State): IO[A] = IO {
+    def boo(cause: Either[Throwable, String]): Nothing = {
+      val err = cause match {
+        case Left(e: TestFailedException)   => e
+        case Left(e: TestCanceledException) => e
+        case abnormal                       => AbnormalTermination(abnormal, tcState)
+      }
+      throw err
+    }
+
+    outcome match {
+      case Some(Right(a)) => a
+      case Some(Left(e))  => boo(Left(e))
+      case None           => boo(Right(s"Not completed. State: $tcState"))
+    }
+  }
+}

--- a/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/TestRuntime.scala
+++ b/testkit/src/main/scala/com/evolutiongaming/catshelper/testkit/TestRuntime.scala
@@ -6,7 +6,18 @@ import scala.concurrent.duration.FiniteDuration
  * Provides access to running test info.
  */
 trait TestRuntime[F[_]] {
+  /**
+   * Returns time on ''test'' clock passed since the start of the test.
+   */
   def getTimeSinceStart: F[FiniteDuration]
+
+  /**
+   * Assuming that tests start at `0`, sleep until it's `dt` time into the test.
+   *
+   * It's roughly equivalent to `getTimeSinceStart.flatMap(t => timer.sleep(dt - t))`
+   * but does not require a `timer: Timer[F]` argument.
+   */
+  def sleepUntil(dt: FiniteDuration): F[Unit]
 }
 
 object TestRuntime {


### PR DESCRIPTION
This PR brings a bunch of things
- split `PureTest` into parts making each one more focused
- introduce more accessible and maintainable way to tweak test options (see inner `Config` and modifier methods on `PureTest`)
- make it possible to override background EC
- add an option for catching flaky behaviour
- make ScalaTest dependency optional

Please note that configuration API changes break backward compatibility. Formally this will require a major version bump, but perhaps we may consider `cats-helper-testkit` experimental for now, and not follow SemVer too strictly?