### PR TITLE
NonEmptyList partitioning

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/NonEmptyListPartitionOps.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/NonEmptyListPartitionOps.scala
@@ -1,0 +1,51 @@
+package com.evolutiongaming.catshelper
+
+import cats.data.NonEmptyList
+import com.evolutiongaming.catshelper.NonEmptyListPartitions.{AllLeft, AllRight}
+
+object NonEmptyListPartitionOps {
+
+  implicit class NonEmptyListPartitionOpsC[T](nel: NonEmptyList[T]) {
+    def split[L, R](classifier: T => Either[L, R]): NonEmptyListPartitions[L, R] = {
+      val value: NonEmptyListPartitions[ L, R] = classifier(nel.head).fold(AllLeft.one, AllRight.one)
+
+      nel.tail.foldLeft(value) { case (acc, nextElement) =>
+        classifier(nextElement).fold(
+          acc.appendLeft,
+          acc.appendRight
+        )
+      }
+    }
+  }
+}
+
+sealed trait NonEmptyListPartitions[L, R] {
+  def appendLeft(l: L): NonEmptyListPartitions[L, R]
+  def appendRight(r: R): NonEmptyListPartitions[L, R]
+}
+
+object NonEmptyListPartitions {
+
+  case class AllLeft[L, R](left: NonEmptyList[L]) extends NonEmptyListPartitions[L, R] {
+    def appendLeft(l: L): NonEmptyListPartitions[L, R] = AllLeft(left :+ l)
+    def appendRight(r: R): NonEmptyListPartitions[L, R] = Both(left, NonEmptyList.one(r))
+  }
+
+  object AllLeft {
+    def one[L, R](head: L): NonEmptyListPartitions[L, R] = AllLeft(NonEmptyList.one(head))
+  }
+
+  case class AllRight[L, R](right: NonEmptyList[R]) extends NonEmptyListPartitions[L, R] {
+    def appendLeft(l: L): NonEmptyListPartitions[L, R] = Both(NonEmptyList.one(l), right)
+    def appendRight(r: R): NonEmptyListPartitions[L, R] = AllRight(right :+ r)
+  }
+
+  object AllRight {
+    def one[L, R](head: R): NonEmptyListPartitions[L, R] = AllRight(NonEmptyList.one(head))
+  }
+
+  case class Both[L, R](left: NonEmptyList[L], right: NonEmptyList[R]) extends NonEmptyListPartitions[L, R] {
+    def appendLeft(l: L): NonEmptyListPartitions[L, R] = copy(left = left :+ l)
+    def appendRight(r: R): NonEmptyListPartitions[L, R] = copy(right = right :+ r)
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/catshelper/NonEmptyListPartitionOpsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/NonEmptyListPartitionOpsSpec.scala
@@ -46,4 +46,91 @@ class NonEmptyListPartitionOpsSpec extends AnyFreeSpec with Matchers {
       )
     }
   }
+
+  "NonEmptyListPartitions.reverse should" - {
+    "return Both when accepting Both" in {
+      Both(
+        NonEmptyList.of(1, 2),
+        NonEmptyList.of("hi", "bye")
+      ).reverse shouldBe Both(
+        NonEmptyList.of(2, 1),
+        NonEmptyList.of("bye", "hi")
+      )
+    }
+
+    "return AllRight when accepting AllRight" in {
+      AllRight(
+        NonEmptyList.of(1, 2),
+      ).reverse shouldBe AllRight(
+        NonEmptyList.of(2, 1)
+      )
+    }
+
+    "return AllLeft when accepting AllLeft" in {
+      AllLeft(
+        NonEmptyList.of(1, 2),
+      ).reverse shouldBe AllLeft(
+        NonEmptyList.of(2, 1)
+      )
+    }
+  }
+
+  "NonEmptyListPartitions.prependLeft should" - {
+    "return Both when accepting Both" in {
+      Both(
+        NonEmptyList.of(1, 2),
+        NonEmptyList.of("hi", "bye")
+      ).prependLeft(0) shouldBe Both(
+        NonEmptyList.of(0, 1, 2),
+        NonEmptyList.of("hi", "bye")
+      )
+    }
+
+    "return Both when accepting AllRight" in {
+      AllRight(
+        NonEmptyList.of(1, 2),
+      ).prependLeft("hi") shouldBe Both(
+        NonEmptyList.one("hi"),
+        NonEmptyList.of(1, 2)
+      )
+    }
+
+    "return AllLeft when accepting AllLeft" in {
+      AllLeft(
+        NonEmptyList.of(1, 2),
+      ).prependLeft(0) shouldBe AllLeft(
+        NonEmptyList.of(0, 1, 2)
+      )
+    }
+  }
+
+  "NonEmptyListPartitions.prependRight should" - {
+    "return Both when accepting Both" in {
+      Both(
+        NonEmptyList.of(1, 2),
+        NonEmptyList.of("hi", "bye")
+      ).prependRight("emm") shouldBe Both(
+        NonEmptyList.of(1, 2),
+        NonEmptyList.of("emm", "hi", "bye")
+      )
+    }
+
+    "return AllRight when accepting AllRight" in {
+      AllRight(
+        NonEmptyList.of(1, 2),
+      ).prependRight(0) shouldBe AllRight(
+        NonEmptyList.of(0,1, 2)
+      )
+    }
+
+    "return Both when accepting AllLeft" in {
+      AllLeft(
+        NonEmptyList.of(1, 2),
+      ).prependRight("hi") shouldBe Both(
+        NonEmptyList.of( 1, 2),
+        NonEmptyList.one("hi")
+      )
+    }
+  }
+
 }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/NonEmptyListPartitionOpsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/NonEmptyListPartitionOpsSpec.scala
@@ -1,0 +1,49 @@
+package com.evolutiongaming.catshelper
+
+import cats.data.NonEmptyList
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.freespec.AnyFreeSpec
+import NonEmptyListPartitions._
+
+class NonEmptyListPartitionOpsSpec extends AnyFreeSpec with Matchers {
+  import NonEmptyListPartitionOps._
+
+  "NonEmptyList should" - {
+    "return LeftNonEmpty if first element is L" in {
+      NonEmptyList.of[Any](1, 2).split({
+        case i: Int    => Left(i)
+        case s: String => Right(s)
+      }) shouldBe AllLeft(
+        NonEmptyList.of(1, 2)
+      )
+    }
+
+    "return RightNonEmpty if first element is R" in {
+      NonEmptyList.of[Any]("s", "r").split({
+        case i: Int    => Left(i)
+        case s: String => Right(s)
+      }) shouldBe AllRight(
+        NonEmptyList.of("s", "r")
+      )
+    }
+    "return BothNonEmpty if first element is L" in {
+      NonEmptyList.of(1, 2, "s", "r").split({
+        case i: Int    => Left(i)
+        case s: String => Right(s)
+      }) shouldBe Both(
+        NonEmptyList.of(1, 2),
+        NonEmptyList.of("s", "r")
+      )
+    }
+
+    "return BothNonEmpty if first element is R" in {
+      NonEmptyList.of("s", "r", 1, 2).split({
+        case i: Int    => Left(i)
+        case s: String => Right(s)
+      }) shouldBe Both(
+        NonEmptyList.of(1, 2),
+        NonEmptyList.of("s", "r")
+      )
+    }
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/catshelper/NonEmptyListPartitionOpsSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/NonEmptyListPartitionOpsSpec.scala
@@ -4,9 +4,9 @@ import cats.data.NonEmptyList
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.freespec.AnyFreeSpec
 import NonEmptyListPartitions._
+import NonEmptyListPartitionOps._
 
 class NonEmptyListPartitionOpsSpec extends AnyFreeSpec with Matchers {
-  import NonEmptyListPartitionOps._
 
   "NonEmptyList should" - {
     "return LeftNonEmpty if first element is L" in {


### PR DESCRIPTION
When splitting `cats.data.NonEmptyList[T]` to two collections we can turn it `toList` and then `split` but that would not give us compilation level guarantee that one of those resulted collections will be non-empty.
To fix that `NonEmptyListPartitions[L,R]` is introduced. `NonEmptyListPartitions[L,R]` can be either `AllLeft[L,R]` either 'AllRight[L,R]` or `Both[L,R]`

Usage:
```
import NonEmptyListPartitionOps._

NonEmptyList.of(1, 2, "s", "r").split({
   case i: Int    => Left(i)
   case s: String => Right(s)
}) shouldBe Both(
   NonEmptyList.of(1, 2),
   NonEmptyList.of("s", "r")
)
```