### PR TITLE
Update cats to 2.4.2, CE to 2.3.3 (same as in scassandra), add groupedNel alias

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/DataHelper.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/DataHelper.scala
@@ -9,7 +9,7 @@ object DataHelper {
 
   implicit class SortedMapOpsDataHelper[K, V](val self: SortedMap[K, V]) extends AnyVal {
 
-    @deprecated("no longer required by cats" , since = "2.1.1")
+    @deprecated("no longer required by cats", since = "2.1.1")
     def toNem(implicit order: Order[K]): Option[Nem[K, V]] = Nem.fromMap(self)
 
     def toNem(): Option[Nem[K, V]] = Nem.fromMap(self)
@@ -79,6 +79,12 @@ object DataHelper {
         Nel(groups.head, groups.tail)
       }
     }
+
+    /**
+     * Alias for [[grouped()]] to avoid name clashing with
+     * [[cats.data.NonEmptyList.grouped]].
+     */
+    def groupedNel(n: Int): Nel[Nel[A]] = grouped(n)
   }
 
 

--- a/core/src/main/scala/com/evolutiongaming/catshelper/NelHelper.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/NelHelper.scala
@@ -9,6 +9,6 @@ object NelHelper {
   @deprecated("use DataHelper instead", "1.2.0")
   class NelOpsNelHelper[A](val self: Nel[A]) extends AnyVal {
 
-    def grouped(n: Int): Nel[Nel[A]] = self.grouped(n)
+    def grouped(n: Int): Nel[Nel[A]] = self.groupedNel(n)
   }
 }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/DataHelperTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/DataHelperTest.scala
@@ -20,10 +20,10 @@ class DataHelperTest extends AnyFunSuite with Matchers {
     Map.empty[Int, Int].toNem shouldEqual none
   }
 
-  test("Nel.grouped") {
+  test("Nel.groupedNel") {
     val actual = Nel
       .of(0, 1, 2, 3, 4)
-      .grouped(2)
+      .groupedNel(2)
     val expected = Nel.of(
       Nel.of(0, 1),
       Nel.of(2, 3),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,12 +9,12 @@ object Dependencies {
   val cpKindProjector = "org.typelevel" % "kind-projector" % "0.13.0" cross CrossVersion.full
 
   object Cats {
-    private val version = "2.3.0"
+    private val version = "2.4.2"
     val core   = "org.typelevel" %% "cats-core"   % version
     val kernel = "org.typelevel" %% "cats-kernel" % version
     val macros = "org.typelevel" %% "cats-macros" % version
 
-    private val effectVersion = "2.3.0"
+    private val effectVersion = "2.3.3"
     val effect     = "org.typelevel" %% "cats-effect"      % effectVersion
     val effectLaws = "org.typelevel" %% "cats-effect-laws" % effectVersion
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "2.2.4-SNAPSHOT"
+ThisBuild / version := "2.3.0-SNAPSHOT"


### PR DESCRIPTION
In cats 2.4 a new "grouped" method was added which clashes with our DataHelper implicit one. "groupedNel" alias for our method should resolve the issue for the library users.