### PR TITLE
Add a way to create log without side effects

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/Log.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/Log.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.catshelper
 import cats.data.NonEmptyMap
 import cats.effect.Sync
 import cats.{Applicative, Semigroup, ~>}
-import org.slf4j.{Logger, MDC}
+import org.slf4j.{ILoggerFactory, Logger, MDC}
 
 import scala.collection.immutable.SortedMap
 
@@ -41,9 +41,11 @@ trait Log[F[_]] {
 object Log {
 
   sealed trait Mdc
+
   object Mdc {
 
     private object Empty extends Mdc
+
     private final case class Context(values: NonEmptyMap[String, String]) extends Mdc {
       override def toString: String = s"MDC(${values.toSortedMap.mkString(", ")})"
     }
@@ -53,7 +55,7 @@ object Log {
     def apply(head: (String, String), tail: (String, String)*): Mdc = Context(NonEmptyMap.of(head, tail: _*))
 
     def fromSeq(seq: Seq[(String, String)]): Mdc =
-      NonEmptyMap.fromMap(SortedMap(seq: _*)).fold(empty){ nem => Context(nem) }
+      NonEmptyMap.fromMap(SortedMap(seq: _*)).fold(empty) { nem => Context(nem) }
 
     def fromMap(map: Map[String, String]): Mdc = fromSeq(map.toSeq)
 
@@ -76,7 +78,7 @@ object Log {
 
   def summon[F[_]](implicit F: Log[F]): Log[F] = F
 
-  def apply[F[_]: Sync](logger: Logger): Log[F] = new Log[F] {
+  def cached[F[_] : Sync](source: String, factory: ILoggerFactory): Log[F] = new Log[F] {
 
     def withMDC(mdc: Log.Mdc)(log: => Unit): Unit = {
       import Mdc.MdcOps
@@ -93,43 +95,142 @@ object Log {
 
     def trace(msg: => String, mdc: Log.Mdc) = {
       Sync[F].delay {
-        if (logger.isTraceEnabled) withMDC(mdc) { logger.trace(msg) }
+        val logger = factory.getLogger(source)
+        if (logger.isTraceEnabled) withMDC(mdc) {
+          logger.trace(msg)
+        }
       }
     }
 
     def debug(msg: => String, mdc: Log.Mdc) = {
       Sync[F].delay {
-        if (logger.isDebugEnabled) withMDC(mdc) { logger.debug(msg) }
+        val logger = factory.getLogger(source)
+
+        if (logger.isDebugEnabled) withMDC(mdc) {
+          logger.debug(msg)
+        }
       }
     }
 
     def info(msg: => String, mdc: Log.Mdc) = {
       Sync[F].delay {
-        if (logger.isInfoEnabled) withMDC(mdc) { logger.info(msg) }
+        val logger = factory.getLogger(source)
+
+        if (logger.isInfoEnabled) withMDC(mdc) {
+          logger.info(msg)
+        }
       }
     }
 
     def warn(msg: => String, mdc: Log.Mdc) = {
       Sync[F].delay {
-        if (logger.isWarnEnabled) withMDC(mdc) { logger.warn(msg) }
+        val logger = factory.getLogger(source)
+
+        if (logger.isWarnEnabled) withMDC(mdc) {
+          logger.warn(msg)
+        }
       }
     }
 
     def warn(msg: => String, cause: Throwable, mdc: Log.Mdc) = {
       Sync[F].delay {
-        if (logger.isWarnEnabled) withMDC(mdc) { logger.warn(msg, cause) }
+        val logger = factory.getLogger(source)
+
+        if (logger.isWarnEnabled) withMDC(mdc) {
+          logger.warn(msg, cause)
+        }
       }
     }
 
     def error(msg: => String, mdc: Log.Mdc) = {
       Sync[F].delay {
-        if (logger.isErrorEnabled) withMDC(mdc) { logger.error(msg) }
+        val logger = factory.getLogger(source)
+
+        if (logger.isErrorEnabled) withMDC(mdc) {
+          logger.error(msg)
+        }
       }
     }
 
     def error(msg: => String, cause: Throwable, mdc: Log.Mdc) = {
       Sync[F].delay {
-        if (logger.isErrorEnabled) withMDC(mdc) { logger.error(msg, cause) }
+        val logger = factory.getLogger(source)
+
+        if (logger.isErrorEnabled) withMDC(mdc) {
+          logger.error(msg, cause)
+        }
+      }
+    }
+  }
+
+  def apply[F[_] : Sync](logger: Logger): Log[F] = new Log[F] {
+
+    def withMDC(mdc: Log.Mdc)(log: => Unit): Unit = {
+      import Mdc.MdcOps
+      mdc.context match {
+        case None => log
+        case Some(mdc) =>
+          val backup = MDC.getCopyOfContextMap
+          MDC.clear()
+          mdc.toSortedMap foreach { case (k, v) => MDC.put(k, v) }
+          log
+          if (backup == null) MDC.clear() else MDC.setContextMap(backup)
+      }
+    }
+
+    def trace(msg: => String, mdc: Log.Mdc) = {
+      Sync[F].delay {
+        if (logger.isTraceEnabled) withMDC(mdc) {
+          logger.trace(msg)
+        }
+      }
+    }
+
+    def debug(msg: => String, mdc: Log.Mdc) = {
+      Sync[F].delay {
+        if (logger.isDebugEnabled) withMDC(mdc) {
+          logger.debug(msg)
+        }
+      }
+    }
+
+    def info(msg: => String, mdc: Log.Mdc) = {
+      Sync[F].delay {
+        if (logger.isInfoEnabled) withMDC(mdc) {
+          logger.info(msg)
+        }
+      }
+    }
+
+    def warn(msg: => String, mdc: Log.Mdc) = {
+      Sync[F].delay {
+        if (logger.isWarnEnabled) withMDC(mdc) {
+          logger.warn(msg)
+        }
+      }
+    }
+
+    def warn(msg: => String, cause: Throwable, mdc: Log.Mdc) = {
+      Sync[F].delay {
+        if (logger.isWarnEnabled) withMDC(mdc) {
+          logger.warn(msg, cause)
+        }
+      }
+    }
+
+    def error(msg: => String, mdc: Log.Mdc) = {
+      Sync[F].delay {
+        if (logger.isErrorEnabled) withMDC(mdc) {
+          logger.error(msg)
+        }
+      }
+    }
+
+    def error(msg: => String, cause: Throwable, mdc: Log.Mdc) = {
+      Sync[F].delay {
+        if (logger.isErrorEnabled) withMDC(mdc) {
+          logger.error(msg, cause)
+        }
       }
     }
   }
@@ -183,7 +284,7 @@ object Log {
     def error(msg: => String, cause: Throwable, mdc: Log.Mdc) = unit
   }
 
-  def empty[F[_]: Applicative]: Log[F] = const(Applicative[F].unit)
+  def empty[F[_] : Applicative]: Log[F] = const(Applicative[F].unit)
 
   implicit class LogOps[F[_]](val self: Log[F]) extends AnyVal {
 


### PR DESCRIPTION
Currently  `LogOf` creates desired `Log` instances with a side-effect. But there is a simple way to avoid that and get plain `Log[F]`, not `F[Log[F]]`. This is possible because of the fact that both SLF4J and Logback cache their loggers (which `LogOf` relies on). 
This means that it is totally fine to call `loggerFactory.getLogger(source)` on each log message, because the overhead is simply a hash table call and a couple of `if`-s.

The names and the details in this PR are subject to change, let's discuss it all.