### PR TITLE
Refactor syntax objects due to #117

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/ClockHelper.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ClockHelper.scala
@@ -7,7 +7,20 @@ import cats.effect.Clock
 import cats.implicits._
 import cats.{Applicative, Functor}
 
-object ClockHelper {
+object ClockHelper extends ClockSyntax
+
+
+trait ClockSyntax {
+
+  import ClockSyntaxOps._
+
+  implicit def toClockOps[F[_]](self: Clock[F]): ClockOps[F] = new ClockOps[F](self)
+
+  implicit def toClockObjOps(self: Clock.type): ClockObjOps = new ClockObjOps(self)
+
+}
+
+private[catshelper] object ClockSyntaxOps {
 
   implicit class ClockOps[F[_]](val self: Clock[F]) extends AnyVal {
 

--- a/core/src/main/scala/com/evolutiongaming/catshelper/ContextShiftHelper.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ContextShiftHelper.scala
@@ -6,11 +6,21 @@ import cats.implicits._
 
 import scala.concurrent.ExecutionContext
 
-object ContextShiftHelper {
+object ContextShiftHelper extends ContextShiftSyntax
+
+trait ContextShiftSyntax {
+
+  import ContextShiftHelperOps._
+
+  implicit def toContextShiftObjContextShiftHelper(self: ContextShift.type) = new ContextShiftObjContextShiftHelper(self)
+}
+
+
+private[catshelper] object ContextShiftHelperOps {
 
   implicit class ContextShiftObjContextShiftHelper(val self: ContextShift.type) extends AnyVal {
 
-    def empty[F[_]: Applicative]: ContextShift[F] = new ContextShift[F] {
+    def empty[F[_] : Applicative]: ContextShift[F] = new ContextShift[F] {
 
       val shift = ().pure[F]
 

--- a/core/src/main/scala/com/evolutiongaming/catshelper/DataHelper.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/DataHelper.scala
@@ -5,7 +5,28 @@ import cats.data.{NonEmptyList => Nel, NonEmptyMap => Nem, NonEmptySet => Nes}
 
 import scala.collection.immutable.{Iterable, SortedMap, SortedSet}
 
-object DataHelper {
+object DataHelper extends DataSyntax
+
+trait DataSyntax {
+
+  import DataHelperOps._
+
+
+  implicit def toSortedMapOpsDataHelper[K, V](self: SortedMap[K, V]): SortedMapOpsDataHelper[K, V] = new SortedMapOpsDataHelper(self)
+
+  implicit def toIterableOpsDataHelper[K, V](self: Iterable[(K, V)]): IterableOpsDataHelper[K, V] = new IterableOpsDataHelper(self)
+
+  implicit def toIterableOps1DataHelper[A](self: Iterable[A]): IterableOps1DataHelper[A] = new IterableOps1DataHelper(self)
+
+  implicit def toNemOpsDataHelper[K, V](self: Nem[K, V]): NemOpsDataHelper[K, V] = new NemOpsDataHelper(self)
+
+  implicit def toNelOpsDataHelper[A](self: Nel[A]): NelOpsDataHelper[A] = new NelOpsDataHelper(self)
+
+  implicit def toNesOpsDataHelper[A](self: Nes[A]): NesOpsDataHelper[A] = new NesOpsDataHelper(self)
+
+}
+
+private[catshelper] object DataHelperOps {
 
   implicit class SortedMapOpsDataHelper[K, V](val self: SortedMap[K, V]) extends AnyVal {
 
@@ -19,7 +40,7 @@ object DataHelper {
   implicit class IterableOpsDataHelper[K, V](val self: Iterable[(K, V)]) extends AnyVal {
 
     def toSortedMap(implicit order: Order[K]): SortedMap[K, V] = {
-      implicit val ordering = order.toOrdering
+      implicit val ordering: Ordering[K] = order.toOrdering
       val builder = SortedMap.newBuilder[K, V]
       builder ++= self
       builder.result()
@@ -36,7 +57,7 @@ object DataHelper {
   implicit class IterableOps1DataHelper[A](val self: Iterable[A]) extends AnyVal {
 
     def toSortedSet(implicit order: Order[A]): SortedSet[A] = {
-      implicit val ordering = Order[A].toOrdering
+      implicit val ordering: Ordering[A] = Order[A].toOrdering
       val builder = SortedSet.newBuilder[A]
       builder ++= self
       builder.result()
@@ -47,7 +68,7 @@ object DataHelper {
   implicit class NemOpsDataHelper[K, V](val self: Nem[K, V]) extends AnyVal {
 
     def mapKV[A: Order, B](f: (K, V) => (A, B)): Nem[A, B] = {
-      implicit val ordering = Order[A].toOrdering
+      implicit val ordering: Ordering[A] = Order[A].toOrdering
       self
         .toSortedMap
         .map { case (k, v) => f(k, v) }
@@ -56,7 +77,7 @@ object DataHelper {
     }
 
     def mapK[A: Order](f: K => A): Nem[A, V] = {
-      implicit val ordering = Order[A].toOrdering
+      implicit val ordering: Ordering[A] = Order[A].toOrdering
       self
         .toSortedMap
         .map { case (k, v) => (f(k), v) }

--- a/core/src/main/scala/com/evolutiongaming/catshelper/ParallelHelper.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ParallelHelper.scala
@@ -2,11 +2,26 @@ package com.evolutiongaming.catshelper
 
 import cats.{Foldable, Monoid, Parallel}
 
-object ParallelHelper {
+object ParallelHelper extends ParallelSyntax
+
+trait ParallelSyntax {
+
+  import ParallelHelperOps._
+
+  implicit def toParallelObjOps_ParallelHelper(self: Parallel.type): ParallelObjOps_ParallelHelper = new ParallelObjOps_ParallelHelper(self)
+
+  implicit def toParallelOps_ParallelHelper[T[_], A](self: T[A]): ParallelOps_ParallelHelper[T, A] = new ParallelOps_ParallelHelper(self)
+
+  implicit def toParallelFOps_ParallelHelper[T[_], F[_], A](self: T[F[A]]): ParallelFOps_ParallelHelper[T, F, A] = new ParallelFOps_ParallelHelper(self)
+
+  implicit def toIterableOnce_ParallelHelper[A](self: TraversableOnce[A]): IterableOnce_ParallelHelper[A] = new IterableOnce_ParallelHelper(self)
+}
+
+private[catshelper] object ParallelHelperOps {
 
   implicit class ParallelObjOps_ParallelHelper(val self: Parallel.type) extends AnyVal {
 
-    def parFoldMap[T[_]: Foldable, F[_], A, B: Monoid](ta: T[A])(f: A => F[B])(implicit P: Parallel[F]): F[B] = {
+    def parFoldMap[T[_] : Foldable, F[_], A, B: Monoid](ta: T[A])(f: A => F[B])(implicit P: Parallel[F]): F[B] = {
       val M = Monoid[B]
       val A = P.applicative
       val zero = A.pure(M.empty)
@@ -16,11 +31,11 @@ object ParallelHelper {
       P.sequential(fa)
     }
 
-    def parFold[T[_]: Foldable, F[_], A: Monoid](tfa: T[F[A]])(implicit P: Parallel[F]): F[A] = {
+    def parFold[T[_] : Foldable, F[_], A: Monoid](tfa: T[F[A]])(implicit P: Parallel[F]): F[A] = {
       parFoldMap(tfa)(Predef.identity)
     }
 
-    def parFoldMapTraversable[F[_]: Parallel, A, B: Monoid](ta: TraversableOnce[A])(f: A => F[B]): F[B] = {
+    def parFoldMapTraversable[F[_] : Parallel, A, B: Monoid](ta: TraversableOnce[A])(f: A => F[B]): F[B] = {
       val P = Parallel[F]
       val M = Monoid[B]
       val A = P.applicative
@@ -32,14 +47,12 @@ object ParallelHelper {
     }
   }
 
-
   implicit class ParallelOps_ParallelHelper[T[_], A](val self: T[A]) extends AnyVal {
 
     def parFoldMap[F[_], B: Monoid](f: A => F[B])(implicit F: Foldable[T], P: Parallel[F]): F[B] = {
       Parallel.parFoldMap(self)(f)
     }
   }
-
 
   implicit class ParallelFOps_ParallelHelper[T[_], F[_], A](val self: T[F[A]]) extends AnyVal {
 
@@ -49,7 +62,7 @@ object ParallelHelper {
   }
 
   implicit class IterableOnce_ParallelHelper[A](val self: TraversableOnce[A]) extends AnyVal {
-    def parFoldMapTraversable[F[_]: Parallel, B: Monoid](f: A => F[B]): F[B] = {
+    def parFoldMapTraversable[F[_] : Parallel, B: Monoid](f: A => F[B]): F[B] = {
       Parallel.parFoldMapTraversable(self)(f)
     }
   }

--- a/core/src/main/scala/com/evolutiongaming/catshelper/TimerHelper.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/TimerHelper.scala
@@ -7,7 +7,18 @@ import com.evolutiongaming.catshelper.ClockHelper._
 
 import scala.concurrent.duration.FiniteDuration
 
-object TimerHelper {
+trait TimerSyntax
+
+object TimerHelper extends TimerSyntax {
+
+  import TimerOps._
+
+  implicit def toTimerObjOpsTimerHelper(self: Timer.type): TimerObjOpsTimerHelper = new TimerObjOpsTimerHelper(self)
+
+}
+
+
+private[catshelper] object TimerOps {
 
   implicit class TimerObjOpsTimerHelper(val self: Timer.type) extends AnyVal {
 

--- a/core/src/main/scala/com/evolutiongaming/catshelper/syntax.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/syntax.scala
@@ -1,0 +1,12 @@
+package com.evolutiongaming.catshelper
+
+object syntax {
+  final val timer = TimerHelper
+  final val parallel = ParallelHelper
+  final val clock = ClockHelper
+  final val data = DataHelper
+  final val contextShift = ContextShiftHelper
+
+
+  object all extends CatsSyntax with ClockSyntax with DataSyntax with ContextShiftSyntax with TimerSyntax with ParallelSyntax
+}

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.catshelper
 import cats.effect.concurrent.{MVar, Ref}
 import cats.effect.{ContextShift, IO, Resource, Timer}
 import cats.implicits._
-import com.evolutiongaming.catshelper.CatsHelper.OpsCatsHelper
+import com.evolutiongaming.catshelper.CatsHelper._
 import com.evolutiongaming.catshelper.testkit.PureTest.ioTest
 import com.evolutiongaming.catshelper.testkit.{PureTest, TestRuntime}
 import org.scalactic.source.Position


### PR DESCRIPTION
I've seen some support in #117, so I made this PR.
It does several things:
- introduces `syntax` object and cats-style val's to import syntax;
- reworks `*Helper` objects to be traits & object in order to create `syntax.all`
- creates `com.evolutiongamin.syntax.all` objects.

Note: this is a breaking change, because someone could have been importing implicit classes explicitly, but now they are not available.