### PR TITLE
Update cats-effect to 3.3.4

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,7 @@ object Dependencies {
     val kernel = "org.typelevel" %% "cats-kernel" % version
     val macros = "org.typelevel" %% "cats-macros" % version
 
-    private val effectVersion = "3.2.9"
+    private val effectVersion = "3.3.4"
     val effect     = "org.typelevel" %% "cats-effect"      % effectVersion
     val effectLaws = "org.typelevel" %% "cats-effect-laws" % effectVersion
     val effectTestkit = "org.typelevel" %% "cats-effect-testkit" % effectVersion


### PR DESCRIPTION
There are some updates to test context, which were motivated by the following:
1. TestContext's API was changed significantly in [this commit](https://github.com/typelevel/cats-effect/commit/6a8128847b86c049475fd847d6487ba3899df8f9#diff-4b01deb3943f56f73dbc15a59ea44ae9888ad9b44df8c5fae1efae4dd5496de4). 
2. Now, `tick(FiniteDuration)` is private and we basically copy-paste it using `tick() + advanceAndTick(FiniteDuration)` in case the duration of the next task is positive and just `tick()` otherwise. The check is due to a new assertion for a strictly positive `FiniteDuration` in `advanceAndTick(FiniteDuration)`
3. There's now an API for calculating the interval between "now" and the next scheduled task (`nextInterval()`)