### PR TITLE
add ResourceRetry

### DIFF
--- a/core/src/test/scala/com/evolutiongaming/catshelper/ResourceRetrySpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ResourceRetrySpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 class ResourceRetrySpec extends AsyncFunSuite with Matchers {
 
   val error  = new Exception(s"text exception")
-  val config = ResourceRetry.Config("test", 5, 10.millis, 100.millis)
+  val config = ResourceRetry.Config("test", 5, 100.millis, 10.millis)
 
   implicit val log   = Log.empty[IO]
   implicit val retry = ResourceRetry.of[IO](config)


### PR DESCRIPTION
Originally this functionality was implemented in UB but can be useful for other cases as well.

This function is made for 1 particular edge case. Imagine resource which has inside infinite fiber. In case of failure this fiber we must release resource, then wait for small period of time, acquire them and start fiber again. Here is mechanism of retry of amount restart with reset in order to implement failure rate (e.g 1 time no more than per 5 minute) So as if there were 4 falls during the day (1 left), and then for 2 hours everything ok. Amount of possible restart reset again to 5.