### PR TITLE
Fix flaky PureTestSpec, simplify and comment PureTestRunner

### DIFF
--- a/testkit/src/test/scala/com/evolutiongaming/catshelper/testkit/PureTestSpec.scala
+++ b/testkit/src/test/scala/com/evolutiongaming/catshelper/testkit/PureTestSpec.scala
@@ -48,8 +48,14 @@ class PureTestSpec extends AnyFreeSpec {
    }
 
   "is unaffected by infinite background loops" in ioTest { _ =>
-    val main = IO.sleep(1.milli)
-    val loop = IO.sleep(1.nano).foreverM
+    // "Unaffected" in this test case means that an infinite background loop does not
+    // prevent PureTest from seeing the result of the main IO and completing the test.
+    // However keep in mind that PureTest still has to "tick" the logical clock for the
+    // background loop, which takes some wall-clock time. So, if the main IO emulates a
+    // log delay while the background loop does millions of tiny increments, ticking
+    // them all might take longer than `hotLoopTimeout`, failing the test as a result.
+    val main = IO.sleep(1.second)
+    val loop = IO.sleep(1.milli).foreverM
     loop.start *> main
   }
 }


### PR DESCRIPTION
`PureTestSpec`  is flaky since recently. See [this build](https://github.com/evolution-gaming/cats-helper/runs/5463321386?check_suite_focus=true#step:5:76) for example.
```
- is unaffected by infinite background loops *** FAILED ***
  com.evolutiongaming.catshelper.testkit.AbnormalTermination: java.lang.IllegalStateException: Canceled. State(1708049,854021 nanoseconds,TreeSet(Task(1708049,cats.effect.IOFiber$$Lambda$8049/0x00000008020c83e0@7792f512,854022 nanoseconds)),None)
  ...
```

The failure is caused by a slowdown somewhere in the underlying runtime, probably in the build agent. Here's the test body
```scala
    val main = IO.sleep(1.milli)
    val loop = IO.sleep(1.nano).foreverM
    loop.start *> main
```
Basically, the test runtime has to "tick" `1.nano` increments 1 million times before completing the main `1.milli` part. Sometimes it fails to do this in 10 seconds of wall-clock time, and the test gets interrupted by the hot loop detection machinery of `PureTest`.

The fix is trivial – reduce the number of loop ticks needed to complete the main part.

----

In addition to the test fix this PR also improves the `PureTestRunner`:
- brings back the cancellation of background hot loop detection machinery, which got for some reason completely removed in b9299c61f162f76ade7028836fec91bfee123f0c
- simplifies the execution logic without sacrificing any feature.