### PR TITLE
Add MeasureDuration test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,13 @@
 import Dependencies._
 
+def crossSettings[T](scalaVersion: String, if3: Seq[T], if2: Seq[T]) = {
+  CrossVersion.partialVersion(scalaVersion) match {
+    case Some((3, _)) => if3
+    case Some((2, 12 | 13)) => if2
+    case _ => Nil
+  }
+}
+
 inThisBuild(Seq(
   homepage := Some(new URL("http://github.com/evolution-gaming/cats-helper")),
 
@@ -52,6 +60,16 @@ lazy val core = project
       `slf4j-api`,
       Logback.classic % Test,
       scalatest % Test,
+    ),
+    libraryDependencies ++= crossSettings(
+      scalaVersion.value,
+      if3 = Nil,
+      if2 = List(compilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full))
+    ),
+    scalacOptions ++= crossSettings(
+      scalaVersion.value,
+      if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions"),
+      if2 = List("-Xsource:3", "-P:kind-projector:underscore-placeholders")
     ),
   )
   .dependsOn(

--- a/core/src/main/scala/com/evolutiongaming/catshelper/LogOf.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/LogOf.scala
@@ -11,7 +11,7 @@ trait LogOf[F[_]] {
 
   def apply(source: String): F[Log[F]]
 
-  def apply(source: Class[_]): F[Log[F]]
+  def apply(source: Class[?]): F[Log[F]]
 }
 
 object LogOf {
@@ -33,7 +33,7 @@ object LogOf {
         Log[F](log)
       }
     }
-    def apply(source: Class[_]) = apply(source.getName.stripSuffix("$"))
+    def apply(source: Class[?]) = apply(source.getName.stripSuffix("$"))
   }
 
 
@@ -58,7 +58,7 @@ object LogOf {
 
     def apply(source: String) = log
 
-    def apply(source: Class[_]) = log
+    def apply(source: Class[?]) = log
   }
 
 
@@ -74,7 +74,7 @@ object LogOf {
         }
       }
 
-      def apply(source: Class[_]) = {
+      def apply(source: Class[?]) = {
         for {
           log <- f(self(source))
         } yield {

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
@@ -103,7 +103,7 @@ object LogSpec {
         }
       }
 
-      def apply(source: Class[_]) = {
+      def apply(source: Class[?]) = {
         StateT { state =>
           val action = Action.OfClass(source)
           (state.add(action), log)
@@ -188,7 +188,7 @@ object LogSpec {
 
   object Action {
     final case class OfStr(source: String) extends Action
-    final case class OfClass(source: Class[_]) extends Action
+    final case class OfClass(source: Class[?]) extends Action
     final case class Trace(msg: String, mdc: Log.Mdc = Log.Mdc.empty) extends Action
     final case class Debug(msg: String, mdc: Log.Mdc = Log.Mdc.empty) extends Action
     final case class Info(msg: String, mdc: Log.Mdc = Log.Mdc.empty) extends Action

--- a/core/src/test/scala/com/evolutiongaming/catshelper/MeasureDurationSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/MeasureDurationSpec.scala
@@ -1,0 +1,118 @@
+package com.evolutiongaming.catshelper
+
+import cats.data.StateT
+import cats.effect.{Clock, IO}
+import cats.{Applicative, Id, Monad}
+import cats.syntax.either._
+import cats.syntax.applicative._
+import cats.syntax.applicativeError._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import com.evolutiongaming.catshelper.syntax.measureDuration._
+import cats.effect.Ref
+import cats.effect.unsafe.implicits.global
+
+import scala.concurrent.duration._
+
+class MeasureDurationSpec extends AnyFunSuite with Matchers {
+
+  import MeasureDurationSpec._
+
+  test("measure duration") {
+    val stateT = for {
+      duration <- MeasureDuration[IdState].start
+      duration <- duration
+    } yield duration
+
+    val (state, duration) = stateT.run(State(List(1.nano, 3.nanos)))
+    duration shouldEqual 2.nanos
+    state shouldEqual State.Empty
+  }
+
+  test("MeasureDurationOps.measured") {
+    val test = Sleep[IdState].sleep(3.seconds).measured {
+      time => StateT.modify[Id, State](old => State(time :: old.timestamps))
+    }
+
+    test.runS(State(List(0.nano, 0.nano))) shouldEqual State(3.seconds :: Nil)
+  }
+
+  test("MeasureDurationOps.measuredCase success") {
+    val test = Sleep[StateT[Either[Throwable, _], State, _]]
+      .sleep(3.seconds)
+      .measuredCase(
+        time => StateT.modify[Either[Throwable, _], State](old => State(time +: old.timestamps)),
+        _ => StateT.modify[Either[Throwable, _], State](old => State(-1.nano +: old.timestamps))
+      )
+
+    test.runS(State(List(0.nano, 0.nano))) shouldEqual State(3.seconds :: Nil).asRight[Throwable]
+  }
+
+  test("MeasureDurationOps.measuredCase failure") {
+    val test = for {
+      ref <- StateT.liftF(Ref.of[IO, List[FiniteDuration]](List.empty))
+      _ <- StateT.liftF[IO, State, Unit](IO.raiseError(new RuntimeException("test"))).measuredCase(
+        _ => StateT.liftF(ref.update(1.day :: _)),
+        time => StateT.liftF(ref.update(time :: _))
+      ).attempt
+      time <- StateT.liftF(ref.get)
+    } yield time
+
+    test.runA(State(List(0.nano, 5.nanos))).unsafeRunSync() shouldEqual List(5.nanos)
+  }
+
+}
+
+object MeasureDurationSpec {
+
+  type IdState[A] = StateT[Id, State, A]
+
+  final case class State(timestamps: List[FiniteDuration]) {
+
+    def timestamp: (State, FiniteDuration) = {
+      timestamps match {
+        case a :: timestamps => (copy(timestamps = timestamps), a)
+        case Nil => (this, 0.nano)
+      }
+    }
+  }
+
+  object State {
+    val Empty: State = State(List.empty)
+  }
+
+  trait Sleep[F[_]] {
+    def sleep(duration: FiniteDuration): F[Unit]
+  }
+
+  object Sleep {
+    def apply[F[_]](implicit ev: Sleep[F]): Sleep[F] = ev
+  }
+
+  implicit def sleep[F[_]: Applicative]: Sleep[StateT[F, State, _]] ={
+    new Sleep[StateT[F, State, _]] {
+      override def sleep(duration: FiniteDuration): StateT[F, State, Unit] =
+        StateT.modify { state =>
+          State(state.timestamps.map(_ + duration))
+        }
+    }
+  }
+
+  implicit def clock[F[_] : Monad]: Clock[StateT[F, State, _]] =
+    new Clock[StateT[F, State, _]] {
+      override def realTime: StateT[F, State, FiniteDuration] =
+        StateT { state =>
+          val (state1, timestamp) = state.timestamp
+          (state1, timestamp).pure[F]
+        }
+
+      def monotonic: StateT[F, State, FiniteDuration] =
+        StateT { state =>
+          val (state1, timestamp) = state.timestamp
+          (state1, timestamp).pure[F]
+        }
+
+      override def applicative: Applicative[StateT[F, State, _]] =
+        Applicative[StateT[F, State, _]]
+    }
+}


### PR DESCRIPTION
MeasureDurationSpec was missed during migration. This PR brings it back. In order to do that, some additional changes in wildcard definition and type parameter placeholders were required to support cross-compilation, see https://docs.scala-lang.org/scala3/reference/changed-features/wildcards.html# for more details