### PR TITLE
implement ResourceCounter

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/ResourceCounter.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ResourceCounter.scala
@@ -1,0 +1,66 @@
+package com.evolutiongaming.catshelper
+
+import cats.effect.{Concurrent, Resource}
+import cats.syntax.all.*
+
+trait ResourceCounter[F[_], A] {
+  def resource: Resource[F, A]
+}
+
+object ResourceCounter {
+
+  def of[F[_]: Concurrent, A](
+    source: Resource[F, A]
+  ): F[ResourceCounter[F, A]] = {
+
+    trait State
+    object State {
+      case class Allocated(a: A, release: F[Unit], count: Int) extends State
+      object Released extends State
+    }
+
+    for {
+      state <- SerialRef.of[F, State](State.Released)
+    } yield
+      new ResourceCounter[F, A] {
+
+        override def resource: Resource[F, A] = {
+
+          val acquire =
+            state.modify {
+
+              case State.Released =>
+                source.allocated.map {
+                  case (a, r) =>
+                    val s: State = State.Allocated(a, r, 1)
+                    s -> a
+                }
+
+              case State.Allocated(a, r, c) =>
+                val s: State = State.Allocated(a, r, c + 1)
+                (s -> a).pure[F]
+            }
+
+          val cleanup =
+            state.update {
+
+              case State.Released =>
+                val msg = "releasing non-acquired ResourceCounter"
+                new IllegalStateException(msg).raiseError[F, State]
+
+              case State.Allocated(a, r, c) =>
+                if (c <= 1) {
+                  r.as[State](State.Released)
+                } else {
+                  val s: State = State.Allocated(a, r, c - 1)
+                  s.pure[F]
+                }
+            }
+
+          Resource.make(acquire)(_ => cleanup)
+        }
+
+      }
+  }
+
+}

--- a/core/src/main/scala/com/evolutiongaming/catshelper/ResourceCounter.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ResourceCounter.scala
@@ -3,6 +3,27 @@ package com.evolutiongaming.catshelper
 import cats.effect.{Concurrent, Resource}
 import cats.syntax.all.*
 
+/** [[ResourceCounter]] is a data structure that allows reusing one [[Resource]] multiple times avoiding re-allocation.
+  *
+  * Resource allocation is lazy and happened on allocation of [[ResourceCounter.resource]]. If [[ResourceCounter.resource]]
+  * allocated again - then the source resource will not be allocated and cached value will be used.
+  * In case of concurrent allocation of [[ResourceCounter.resource]] the source resource guaranteed to be allocated only once,
+  * same rule applied for releasing resource. The release will happened after last [[ResourceCounter.resource]] is released.
+  *
+  * [[ResourceCounter]] can be reused multiple times - after is was allocated/released first time one can allocate it again, sample:
+  * {{{
+  *   val source: Resource[IO, Unit] = ???
+  *   for {
+  *     rc <- ResourceCounter.of(source)
+  *     _ <- rc.resource.use_ // allocated & released
+  *     _ <- rc.resource.use_ // allocated & released again
+  *     _ <- rc.resource.use_ // allocated & released and again
+  *   } yield {}
+  * }}}
+  *
+  * @tparam F the effect type
+  * @tparam A the type of resource
+  */
 trait ResourceCounter[F[_], A] {
   def resource: Resource[F, A]
 }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ResourceCounterSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ResourceCounterSpec.scala
@@ -1,0 +1,113 @@
+package com.evolutiongaming.catshelper
+
+import cats.effect.std.CountDownLatch
+import cats.effect.syntax.all.*
+import cats.effect.unsafe.IORuntime
+import cats.effect.{Deferred, IO, Ref, Resource}
+import com.evolutiongaming.catshelper.testkit.PureTest.ioTest
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ResourceCounterSpec extends AnyFreeSpec with Matchers {
+  implicit val ioRuntime: IORuntime = IORuntime.global
+
+  "source resource allocated/released only once" in ioTest { env =>
+    import env.*
+
+    for {
+      allocations <- Ref.of[IO, Int](0)
+      releases <- Ref.of[IO, Int](0)
+      source = Resource.make[IO, Unit](allocations.update(_ + 1))(
+        _ => releases.update(_ + 1)
+      )
+
+      counter <- ResourceCounter.of(source)
+
+      release1 <- counter.resource.allocated.map(_._2)
+      _ <- allocations.get.map(_ shouldBe 1)
+      _ <- releases.get.map(_ shouldBe 0)
+
+      release2 <- counter.resource.allocated.map(_._2)
+      _ <- allocations.get.map(_ shouldBe 1)
+      _ <- releases.get.map(_ shouldBe 0)
+
+      _ <- release1
+      _ <- allocations.get.map(_ shouldBe 1)
+      _ <- releases.get.map(_ shouldBe 0)
+
+      _ <- release2
+      _ <- allocations.get.map(_ shouldBe 1)
+      _ <- releases.get.map(_ shouldBe 1)
+    } yield {}
+  }
+
+  "source resource allocated/released only once in concurrent usage" in ioTest {
+    env =>
+      import env.*
+
+      val n = 10
+
+      for {
+        allocations <- Ref.of[IO, Int](0)
+        releases <- Ref.of[IO, Int](0)
+        source = Resource.make[IO, Unit](allocations.update(_ + 1))(
+          _ => releases.update(_ + 1)
+        )
+
+        counter <- ResourceCounter.of(source)
+        barrier <- CountDownLatch[IO](n)
+
+        fiber <- Range(0, n).toVector
+          .parTraverseN(32) { _ =>
+            counter.resource.use { _ =>
+              for {
+                _ <- allocations.get.map(_ shouldBe 1)
+                _ <- releases.get.map(_ shouldBe 0)
+                _ <- barrier.release
+                _ <- barrier.await
+              } yield {}
+            }
+          }
+          .start
+
+        _ <- fiber.joinWithNever
+        _ <- allocations.get.map(_ shouldBe 1)
+        _ <- releases.get.map(_ shouldBe 1)
+      } yield {}
+  }
+
+  "source resource can be re-allocated if it was previously released" in ioTest {
+    env =>
+      import env.*
+
+      for {
+        allocations <- Ref.of[IO, Int](0)
+        releases <- Ref.of[IO, Int](0)
+        source = Resource.make[IO, Unit](allocations.update(_ + 1))(
+          _ => releases.update(_ + 1)
+        )
+
+        counter <- ResourceCounter.of(source)
+
+        _ <- counter.resource.use { _ =>
+          for {
+            _ <- allocations.get.map(_ shouldBe 1)
+            _ <- releases.get.map(_ shouldBe 0)
+          } yield {}
+        }
+
+        _ <- allocations.get.map(_ shouldBe 1)
+        _ <- releases.get.map(_ shouldBe 1)
+
+        _ <- counter.resource.use { _ =>
+          for {
+            _ <- allocations.get.map(_ shouldBe 2)
+            _ <- releases.get.map(_ shouldBe 1)
+          } yield {}
+        }
+
+        _ <- allocations.get.map(_ shouldBe 2)
+        _ <- releases.get.map(_ shouldBe 2)
+      } yield {}
+  }
+}


### PR DESCRIPTION
Motivation:

`ResourceCounter` provides caching mechanic for `Resource` by allocating source only once and caching its value & release effect. Every next `ResourceCounter.resource` will reuse cached value while release will be executed on releasing last resource `ResourceCounter.resource`.

`ResourceCounter` was inspired by Rust [Arc](https://doc.rust-lang.org/std/sync/struct.Arc.html) and would be used in [smetrics](https://github.com/evolution-gaming/smetrics/pull/271)