### PR TITLE
Added LoggerInterpolatorSyntax, to make logging slightly more convenient

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ trait Log[F[_]] {
 }
 ```
 
+Syntax extensions are also available, allowing to log like a string interpolator:
+
+```scala
+import com.evolutiongaming.catshelper.syntax.LoggerInterpolatorSyntax.Interpolator
+
+info"info log"
+
+warn"warn log"
+
+error"error log"
+
+debug"debug log"
+
+trace"trace log"
+
+```
+
 ## Runtime
 
 ```scala

--- a/core/src/main/scala/com/evolutiongaming/catshelper/syntax/LoggerInterpolatorSyntax.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/syntax/LoggerInterpolatorSyntax.scala
@@ -1,0 +1,27 @@
+package com.evolutiongaming.catshelper.syntax
+
+import com.evolutiongaming.catshelper.Log
+
+/**
+ * Tiny syntax code to log like a string interpolator.
+ * e.g. info"App starting.."
+ */
+object LoggerInterpolatorSyntax {
+
+  implicit final class Interpolator(private val sc: StringContext) extends AnyVal {
+    def error[F[_]](message: Any*)(implicit logger: Log[F]): F[Unit] =
+      logger.error(sc.s(message: _*))
+
+    def warn[F[_]](message: Any*)(implicit logger: Log[F]): F[Unit] =
+      logger.warn(sc.s(message: _*))
+
+    def info[F[_]](message: Any*)(implicit logger: Log[F]): F[Unit] =
+      logger.info(sc.s(message: _*))
+
+    def debug[F[_]](message: Any*)(implicit logger: Log[F]): F[Unit] =
+      logger.debug(sc.s(message: _*))
+
+    def trace[F[_]](message: Any*)(implicit logger: Log[F]): F[Unit] =
+      logger.trace(sc.s(message: _*))
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
@@ -11,7 +11,7 @@ import com.evolutiongaming.catshelper.IOSuite._
 
 class LogSpec extends AnyFunSuite with Matchers {
 
-  import LogSpec._
+  import LogSpec.*
 
   test("trace, debug, info, warn, error") {
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
@@ -11,7 +11,7 @@ import com.evolutiongaming.catshelper.IOSuite._
 
 class LogSpec extends AnyFunSuite with Matchers {
 
-  import LogSpec.*
+  import LogSpec._
 
   test("trace, debug, info, warn, error") {
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LoggerInterpolatorSyntaxSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LoggerInterpolatorSyntaxSpec.scala
@@ -1,0 +1,32 @@
+package com.evolutiongaming.catshelper
+
+import com.evolutiongaming.catshelper.syntax.LoggerInterpolatorSyntax.Interpolator
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class LoggerInterpolatorSyntaxSpec extends AnyFunSuite with Matchers {
+
+  import LogSpec.*
+
+  test("trace, debug, info, warn, error works with LoggerInterpolator syntax") {
+    implicit val log0 = log
+
+    val stateT = for {
+      _ <- trace"trace"
+      _ <- debug"debug"
+      _ <- info"info"
+      _ <- warn"warn"
+      _ <- error"error"
+    } yield {}
+
+
+    val (state, _) = stateT.run(State(Nil))
+    state shouldEqual State(List(
+      Action.Error0("error"),
+      Action.Warn0("warn"),
+      Action.Info("info"),
+      Action.Debug("debug"),
+      Action.Trace("trace"),
+    ))
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LoggerInterpolatorSyntaxSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LoggerInterpolatorSyntaxSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 
 class LoggerInterpolatorSyntaxSpec extends AnyFunSuite with Matchers {
 
-  import LogSpec.*
+  import LogSpec._
 
   test("trace, debug, info, warn, error works with LoggerInterpolator syntax") {
     implicit val log0 = log

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LoggerInterpolatorSyntaxSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LoggerInterpolatorSyntaxSpec.scala
@@ -3,10 +3,9 @@ package com.evolutiongaming.catshelper
 import com.evolutiongaming.catshelper.syntax.LoggerInterpolatorSyntax.Interpolator
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import LogSpec._
 
 class LoggerInterpolatorSyntaxSpec extends AnyFunSuite with Matchers {
-
-  import LogSpec._
 
   test("trace, debug, info, warn, error works with LoggerInterpolator syntax") {
     implicit val log0 = log


### PR DESCRIPTION
Added a LoggerInterpolator, to make logging slightly more convenient. 
E.g. 
implicit val log: Log[F] = ???
info"Info log"

note: it's almost fully copied from log4cats