### PR TITLE
Try to extract LoggerContext via slf4j api first

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Suggested approach is in using exactly same logback version as used in `cats-hel
 
 #### SLF4J compatibility
 In some cases it may be necessary to allocate the logback instance manually as well as using the SLF4J API in the end user code. However, if multiple LoggerContexts are instantiated at the same time, this could lead to unexpected behaviour, such as the RollingFileAppender writing to multiple files instead of one.
-To cover such cases, the internal implementations of `LogOfFromLogback` use the SLF4J API to instantiate the logback context, so that later use of the SLF4J API will pick up the same context instance created by `LogOfFromLogback`.
+To cover such cases, the internal implementation of `LogOfFromLogback` uses the SLF4J API to instantiate the logback context, so that later use of the SLF4J API will pick up the same context instance created by `LogOfFromLogback`.
 
 ## PureTest
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,27 @@ ftService.use { access =>
 }
 ```
 
+## Logback module
+
+### Separate module
+
+The logback module lives in a separate `cats-helper-logback' module to avoid dependency on a logback in case the user chooses a different logging backend. This is important to avoid the problem of multiple bindings when mapping the logging framework with SLF4J.
+
+### LogOfFromLogback
+
+#### Motivation
+Direct logback usage required to overcome limitations of SLF4J MDC API.
+SLF4J MDC API heavily rely on [[ThreadLocal]], example: ch.qos.logback.classic.util.LogbackMDCAdapter
+Logback' [[LoggingEvent]] allow setting MDC directly as Java map that should have performance benefits compared with SLF4J/Logback implementation.
+
+#### CAUTION!
+Please be aware that using other version of logback (than used in `cats-helper-logback`) might bring '''RUNTIME ERRORS''' or '''MISSING LOGS''' in case of binary incompatibility between them.
+Suggested approach is in using exactly same logback version as used in `cats-helper-logback` (among all others available through transitive dependencies)
+
+#### SLF4J compatibility
+In some cases it may be necessary to allocate the logback instance manually as well as using the SLF4J API in the end user code. However, if multiple LoggerContexts are instantiated at the same time, this could lead to unexpected behaviour, such as the RollingFileAppender writing to multiple files instead of one.
+To cover such cases, the internal implementations of `LogOfFromLogback` use the SLF4J API to instantiate the logback context, so that later use of the SLF4J API will pick up the same context instance created by `LogOfFromLogback`.
+
 ## PureTest
 
 This helper lives in a separate `cats-helper-testkit` module. It is makes testing `F[_]`-based code easier.

--- a/logback/src/main/scala/com/evolutiongaming/catshelper/LogOfFromLogback.scala
+++ b/logback/src/main/scala/com/evolutiongaming/catshelper/LogOfFromLogback.scala
@@ -26,6 +26,7 @@ object LogOfFromLogback {
 
   def apply[F[_]: Sync]: F[LogOf[F]] =
     Sync[F].delay {
+      // see SLF4J compatibility Readme section
       val slf4jCtx = Try { org.slf4j.LoggerFactory.getILoggerFactory().asInstanceOf[ch.qos.logback.classic.LoggerContext] }
       val context  = slf4jCtx.getOrElse(new ch.qos.logback.classic.LoggerContext())
       new ContextInitializer(context).autoConfig()

--- a/logback/src/main/scala/com/evolutiongaming/catshelper/LogOfFromLogback.scala
+++ b/logback/src/main/scala/com/evolutiongaming/catshelper/LogOfFromLogback.scala
@@ -6,7 +6,8 @@ import ch.qos.logback.classic.spi.LoggingEvent
 import ch.qos.logback.classic.util.ContextInitializer
 import com.evolutiongaming.catshelper.Log.Mdc
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
+import scala.util.Try
 
 // format: off
 /**
@@ -25,7 +26,8 @@ object LogOfFromLogback {
 
   def apply[F[_]: Sync]: F[LogOf[F]] =
     Sync[F].delay {
-      val context = new ch.qos.logback.classic.LoggerContext()
+      val slf4jCtx = Try { org.slf4j.LoggerFactory.getILoggerFactory().asInstanceOf[ch.qos.logback.classic.LoggerContext] }
+      val context  = slf4jCtx.getOrElse(new ch.qos.logback.classic.LoggerContext())
       new ContextInitializer(context).autoConfig()
       new LogOf[F] {
 


### PR DESCRIPTION
Problem: Manual allocation of a logback context and later use the SLF4J API (e.g. via akka). SLF4J is not aware about the previously created context and creates and initialises a new one. This is not normal and leads to unwanted behaviour, e.g. RollingFileAppender can write to multiple files at the same time.
Solution: Logback already depends on the slf4j API https://github.com/qos-ch/logback/blob/02e7ef009ceb33295b0b6777c4f23e422454e280/pom.xml#L170-L174, so we can use it to not create the context manually, in this case later use of the slf4j API won't create another instance of the context.