### PR TITLE
Draft: experiments on making logging API simpler to use

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/Logger.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/Logger.scala
@@ -1,0 +1,38 @@
+package com.evolutiongaming.catshelper
+
+import scala.reflect.ClassTag
+
+/** Named [[Logger]] instance.
+  * 
+  * Could be used to log the messages safely if [[Logging]] is available or
+  * unsafely by calling [[Logger#unsafe]] method instead (in this case one
+  * might want to wrap the call into `Sync[F].delay` to keep the referential
+  * transparency intact).
+  */
+class Logger(slf4j: org.slf4j.Logger) {
+  
+  def unsafe: org.slf4j.Logger = slf4j
+
+  def debug[F[_]: Logging](message: String): F[Unit] =
+    Logging[F].debug(this, message)
+
+  def info[F[_]: Logging](message: String): F[Unit] =
+    Logging[F].info(this, message)
+
+  def warn[F[_]: Logging](message: String): F[Unit] =
+    Logging[F].warn(this, message)
+
+  def error[F[_]: Logging](message: String): F[Unit] =
+    Logging[F].error(this, message)
+
+}
+
+object Logger {
+
+  def forClass[C](implicit tag: ClassTag[C]): Logger =
+    forClass(tag.runtimeClass)
+
+  def forClass(clazz: Class[?]): Logger =
+    new Logger(org.slf4j.LoggerFactory.getLogger(clazz))
+    
+}

--- a/core/src/main/scala/com/evolutiongaming/catshelper/Logging.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/Logging.scala
@@ -1,0 +1,30 @@
+package com.evolutiongaming.catshelper
+
+import cats.effect.kernel.Sync
+
+/** Capability of logging messages using a given [[Logger]] instance */
+trait Logging[F[_]] {
+
+  def debug(logger: Logger, message: String): F[Unit]
+  def info(logger: Logger, message: String): F[Unit]
+  def warn(logger: Logger, message: String): F[Unit]
+  def error(logger: Logger, message: String): F[Unit]
+
+}
+
+object Logging {
+
+  def apply[F[_]](implicit F: Logging[F]): Logging[F] = F
+  
+  def fromSync[F[_]: Sync]: Logging[F] = new Logging[F] {
+    def debug(logger: Logger, message: String): F[Unit] =
+      Sync[F].delay(logger.unsafe.debug(message))
+    def info(logger: Logger, message: String): F[Unit] =
+      Sync[F].delay(logger.unsafe.info(message))    
+    def warn(logger: Logger, message: String): F[Unit] =
+      Sync[F].delay(logger.unsafe.warn(message))
+    def error(logger: Logger, message: String): F[Unit] =
+      Sync[F].delay(logger.unsafe.error(message))
+  }
+
+}

--- a/core/src/main/scala/com/evolutiongaming/catshelper/StrictLogging.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/StrictLogging.scala
@@ -1,0 +1,18 @@
+package com.evolutiongaming.catshelper
+
+/** Example usage:
+  *    
+  * {{{
+  * class ExampleService[F[_]: Logging] extends StrictLogging {
+  * 
+  *   def doSomething: F[Unit] =
+  *     logger.info("Doing something")
+  * 
+  * }
+  * }}} 
+  */
+trait StrictLogging {
+
+  protected val logger: Logger = Logger.forClass(getClass)
+  
+}


### PR DESCRIPTION
The idea is to accept the creation of `Logger` instances as something that could be considered reasonably safe and then achieve a simplicity of `scala-logging` API.

I.e. one should only need to extend `StrictLogging` trait and be able to log the stuff immediately given `Logging` capability is provided.

I.e. doing something like this should be possible:
```scala
class ExampleService[F[_]: Logging] extends StrictLogging {

  def doSomething: F[Unit] =
    logger.info("Doing something")

}
```

This is not a final API, but only an experiment for now. The final version may need macros to avoid calculating complicated arguments is logging level is not enabled, and the support of MDC and structural logging before PR could be considered to be accepted.