### PR TITLE
fix context initialization

### DIFF
--- a/logback/src/main/scala/com/evolutiongaming/catshelper/LogOfFromLogback.scala
+++ b/logback/src/main/scala/com/evolutiongaming/catshelper/LogOfFromLogback.scala
@@ -28,8 +28,10 @@ object LogOfFromLogback {
     Sync[F].delay {
       // see SLF4J compatibility Readme section
       val slf4jCtx = Try { org.slf4j.LoggerFactory.getILoggerFactory().asInstanceOf[ch.qos.logback.classic.LoggerContext] }
-      val context  = slf4jCtx.getOrElse(new ch.qos.logback.classic.LoggerContext())
-      new ContextInitializer(context).autoConfig()
+      val context  = slf4jCtx.getOrElse {
+        val ctx = new ch.qos.logback.classic.LoggerContext()
+        new ContextInitializer(ctx).autoConfig()
+      }
       new LogOf[F] {
 
         def apply(source: String): F[Log[F]] = Sync[F].delay {

--- a/logback/src/main/scala/com/evolutiongaming/catshelper/LogOfFromLogback.scala
+++ b/logback/src/main/scala/com/evolutiongaming/catshelper/LogOfFromLogback.scala
@@ -31,6 +31,7 @@ object LogOfFromLogback {
       val context  = slf4jCtx.getOrElse {
         val ctx = new ch.qos.logback.classic.LoggerContext()
         new ContextInitializer(ctx).autoConfig()
+        ctx
       }
       new LogOf[F] {
 


### PR DESCRIPTION
Initialising the context twice causes the log appender to write duplicate log entries