### PR TITLE
Adopt shared Scala CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,17 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        scala:
-          - 2.13.18
-          - 3.3.7
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - uses: coursier/cache-action@v6
-
-      - name: scala
-        uses: olafurpg/setup-scala@v11
-        with:
-          java-version: 17
-
-      - name: build ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} clean coverage test
-
-      - name: test coverage
-        if: success()
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_FLAG_NAME: Scala ${{ matrix.scala }}
-        run: sbt ++${{ matrix.scala }} coverageReport coverageAggregate coveralls
-
-      - name: slack
-        uses: homoluctus/slatify@master
-        if: failure() && github.ref == 'refs/heads/master'
-        with:
-          type: ${{ job.status }}
-          job_name: Build
-          url: ${{ secrets.SLACK_WEBHOOK }}
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@add-scala-ci-workflow
+    secrets: inherit
+    with:
+      scala_versions: '["2.13.18", "3.3.7"]'
+      # TODO both gaps are pre-existing: `check` was stubbed to `show version`, so neither was
+      # actually enforced. Enable once sbt-version-policy and sbt-scalafmt are added.
+      version_policy_check: false
+      scalafmt_check: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@dde27b9bd793d41d5aacf8fb74403c9de5da1146 # v6.3.0
     with:
       scala_versions: '["2.13.18", "3.3.7"]'
       # TODO both gaps are pre-existing: `check` was stubbed to `show version`, so neither was

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@2a389d2a5f4b093e72f738464bd7472bd0c3b4b8 # v6
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0
     with:
       scala_versions: '["2.13.18", "3.3.7"]'
       # TODO both gaps are pre-existing: `check` was stubbed to `show version`, so neither was

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@v6
-    secrets: inherit
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@2a389d2a5f4b093e72f738464bd7472bd0c3b4b8 # v6
     with:
       scala_versions: '["2.13.18", "3.3.7"]'
       # TODO both gaps are pre-existing: `check` was stubbed to `show version`, so neither was

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@add-scala-ci-workflow
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@v6
     secrets: inherit
     with:
       scala_versions: '["2.13.18", "3.3.7"]'


### PR DESCRIPTION
Replaces the hand-written ci.yml with a call to the shared workflow. Also drops the deprecated olafurpg/setup-scala action.

Binary-compatibility and scalafmt checks are switched off explicitly because this repo has neither sbt-version-policy nor sbt-scalafmt. Both were already unenforced: `check` is stubbed to `show version`. The shared workflow makes the gap visible instead of silent.

Part of evolution-gaming/scala-github-actions#5