### PR TITLE
Fix MDC handling and Log defects

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/Log.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/Log.scala
@@ -60,26 +60,47 @@ object Log {
   sealed trait Mdc
   object Mdc {
 
+    /**
+     * Two `Mdc` values are equal when they carry the same records, no matter whether they are held
+     * eagerly or behind a thunk. Comparing forces a [[LazyContext]].
+     */
+    private def equalsOf(self: Mdc, obj: Any): Boolean = obj match {
+      case that: Mdc => contextOf(self) == contextOf(that)
+      case _ => false
+    }
+
+    private def hashCodeOf(self: Mdc): Int = contextOf(self).hashCode()
+
     private object Empty extends Mdc {
       override def toString: String = "MDC()"
+
+      override def hashCode(): Int = hashCodeOf(this)
+
+      override def equals(obj: Any): Boolean = equalsOf(this, obj)
     }
     private final case class EagerContext(values: NonEmptyMap[String, String]) extends Mdc {
       override def toString: String = s"MDC(${ values.toSortedMap.mkString(", ") })"
+
+      override def hashCode(): Int = hashCodeOf(this)
+
+      override def equals(obj: Any): Boolean = equalsOf(this, obj)
     }
     private final class LazyContext(val getMdc: () => Mdc) extends Mdc {
 
       override def toString: String = getMdc().toString
 
-      override def hashCode(): Int = getMdc().hashCode()
+      override def hashCode(): Int = hashCodeOf(this)
 
-      override def equals(obj: Any): Boolean = obj match {
-        case that: LazyContext => this.getMdc().equals(that.getMdc())
-        case _ => false
-      }
+      override def equals(obj: Any): Boolean = equalsOf(this, obj)
     }
     private object LazyContext {
       def apply(mdc: => Mdc): LazyContext = new LazyContext(() => mdc)
     }
+
+    /**
+     * Defers building an `Mdc` until the records are actually needed.
+     */
+    private[Log] def defer(mdc: => Mdc): Mdc = LazyContext(mdc)
 
     val empty: Mdc = Empty
 
@@ -185,28 +206,29 @@ object Log {
 
     implicit final val mdcSemigroup: Semigroup[Mdc] = {
       @tailrec def joinContexts(c1: Mdc, c2: Mdc): Mdc = (c1, c2) match {
-        case (Empty, right) => right
-        case (left, Empty) => left
+        case (left: LazyContext, right) => joinContexts(left.getMdc(), right)
+        case (left, right: LazyContext) => joinContexts(left, right.getMdc())
         case (EagerContext(v1), EagerContext(v2)) => EagerContext(v1 ++ v2)
-        case (c1: LazyContext, c2: LazyContext) => joinContexts(c1.getMdc(), c2.getMdc())
-        case (c1: LazyContext, c2: EagerContext) => joinContexts(c1.getMdc(), c2)
-        case (c1: EagerContext, c2: LazyContext) => joinContexts(c1, c2.getMdc())
+        case (left: EagerContext, _) => left
+        case (_, right) => right
       }
 
       Semigroup.instance(joinContexts)
     }
 
+    /**
+     * Matches on subtypes rather than on `Empty` itself: a stable identifier pattern would call
+     * `Empty.equals`, which resolves back through here.
+     */
+    @tailrec private def contextOf(mdc: Mdc): Option[NonEmptyMap[String, String]] = mdc match {
+      case eagerContext: EagerContext => Some(eagerContext.values)
+      case lazyContext: LazyContext => contextOf(lazyContext.getMdc())
+      case _ => None
+    }
+
     implicit final class MdcOps(val mdc: Mdc) extends AnyVal {
 
-      def context: Option[NonEmptyMap[String, String]] = {
-        @tailrec def contextInner(mdc: Mdc): Option[NonEmptyMap[String, String]] = mdc match {
-          case Empty => None
-          case EagerContext(values) => Some(values)
-          case lc: LazyContext => contextInner(lc.getMdc())
-        }
-
-        contextInner(mdc)
-      }
+      def context: Option[NonEmptyMap[String, String]] = contextOf(mdc)
     }
   }
 
@@ -228,10 +250,13 @@ object Log {
         case None => log
         case Some(mdc) =>
           val backup = MDC.getCopyOfContextMap
-          MDC.clear()
-          mdc.toSortedMap foreach { case (k, v) => MDC.put(k, v) }
-          log
-          if (backup == null) MDC.clear() else MDC.setContextMap(backup)
+          try {
+            MDC.clear()
+            mdc.toSortedMap foreach { case (k, v) => MDC.put(k, v) }
+            log
+          } finally {
+            if (backup == null) MDC.clear() else MDC.setContextMap(backup)
+          }
       }
     }
 
@@ -323,7 +348,7 @@ object Log {
     override def warn(msg: => String, cause: Throwable, mdc: Mdc): F[Unit] = C.println(log("WARN", msg, mdc)) >>
       C.printStackTrace(cause)
 
-    override def error(msg: => String, mdc: Mdc): F[Unit] = C.errorln(log("ERRROR", msg, mdc))
+    override def error(msg: => String, mdc: Mdc): F[Unit] = C.errorln(log("ERROR", msg, mdc))
 
     override def error(msg: => String, cause: Throwable, mdc: Mdc): F[Unit] = C.errorln(log("ERROR", msg, mdc)) >>
       C.printStackTrace(cause)
@@ -370,21 +395,25 @@ object Log {
 
     def withField(key: String, value: String): Log[F] = prefixed(s"$key=$value")
 
+    /**
+     * `f` is applied behind [[Mdc.defer]] so that a [[Mdc.Lazy]] passed by the caller stays
+     * unforced until the underlying logger decides the record is actually going to be written.
+     */
     def mapMdc(f: Log.Mdc => Log.Mdc): Log[F] = new Log[F] {
 
-      def trace(msg: => String, mdc: Mdc): F[Unit] = self.trace(msg, f(mdc))
+      def trace(msg: => String, mdc: Mdc): F[Unit] = self.trace(msg, Mdc.defer(f(mdc)))
 
-      def debug(msg: => String, mdc: Mdc): F[Unit] = self.debug(msg, f(mdc))
+      def debug(msg: => String, mdc: Mdc): F[Unit] = self.debug(msg, Mdc.defer(f(mdc)))
 
-      def info(msg: => String, mdc: Mdc): F[Unit] = self.info(msg, f(mdc))
+      def info(msg: => String, mdc: Mdc): F[Unit] = self.info(msg, Mdc.defer(f(mdc)))
 
-      def warn(msg: => String, mdc: Mdc): F[Unit] = self.warn(msg, f(mdc))
+      def warn(msg: => String, mdc: Mdc): F[Unit] = self.warn(msg, Mdc.defer(f(mdc)))
 
-      def warn(msg: => String, cause: Throwable, mdc: Mdc): F[Unit] = self.warn(msg, cause, f(mdc))
+      def warn(msg: => String, cause: Throwable, mdc: Mdc): F[Unit] = self.warn(msg, cause, Mdc.defer(f(mdc)))
 
-      def error(msg: => String, mdc: Mdc): F[Unit] = self.error(msg, f(mdc))
+      def error(msg: => String, mdc: Mdc): F[Unit] = self.error(msg, Mdc.defer(f(mdc)))
 
-      def error(msg: => String, cause: Throwable, mdc: Mdc): F[Unit] = self.error(msg, cause, f(mdc))
+      def error(msg: => String, cause: Throwable, mdc: Mdc): F[Unit] = self.error(msg, cause, Mdc.defer(f(mdc)))
     }
 
     def withMdc(mdc: Log.Mdc): Log[F] = mapMdc(mdc1 => mdc |+| mdc1)

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
@@ -9,9 +9,10 @@ import cats.effect.{IO, SyncIO}
 import com.evolutiongaming.catshelper.IOSuite._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.slf4j.{Logger, MDC}
+import org.slf4j.event.Level
+import org.slf4j.helpers.AbstractLogger
+import org.slf4j.{MDC, Marker}
 
-import java.lang.reflect.{InvocationHandler, Method, Proxy}
 import java.nio.charset.Charset
 import java.util.concurrent.atomic.AtomicInteger
 import scala.jdk.CollectionConverters._
@@ -156,21 +157,7 @@ class LogSpec extends AnyFunSuite with Matchers {
   }
 
   test("logging does not disturb the caller MDC when the logger throws") {
-    val logger = Proxy
-      .newProxyInstance(
-        getClass.getClassLoader,
-        Array(classOf[Logger]),
-        new InvocationHandler {
-          def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
-            method.getName match {
-              case "isInfoEnabled" => java.lang.Boolean.TRUE
-              case "info" => throw Error
-              case _ => null
-            }
-          }
-        },
-      )
-      .asInstanceOf[Logger]
+    val logger = new StubLogger(levelsEnabled = true, onLog = () => throw Error)
 
     def contextMap = Option(MDC.getCopyOfContextMap).fold(Map.empty[String, String])(_.asScala.toMap)
 
@@ -217,7 +204,7 @@ class LogSpec extends AnyFunSuite with Matchers {
 
   test("Log.console labels errors as ERROR") {
     val result = for {
-      lines <- Ref[IO].of(List.empty[String])
+      linesRef <- Ref[IO].of(List.empty[String])
       _ <- {
         implicit val console: Console[IO] = new Console[IO] {
           def readLineWithCharset(charset: Charset) = IO.raiseError[String](new UnsupportedOperationException)
@@ -240,12 +227,12 @@ class LogSpec extends AnyFunSuite with Matchers {
             a: A,
           )(implicit
             show: Show[A],
-          ) = lines.update(show.show(a) :: _)
+          ) = linesRef.update(show.show(a) :: _)
         }
 
         Log.console[IO]("source").error("message")
       }
-      lines <- lines.get
+      lines <- linesRef.get
     } yield {
       lines should contain("ERROR\tsource: message")
     }
@@ -254,18 +241,7 @@ class LogSpec extends AnyFunSuite with Matchers {
   }
 
   test("withMdc does not force a lazy MDC when the level is disabled") {
-    val logger = Proxy
-      .newProxyInstance(
-        getClass.getClassLoader,
-        Array(classOf[Logger]),
-        new InvocationHandler {
-          def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
-            val name = method.getName
-            if (name.startsWith("is") && name.endsWith("Enabled")) java.lang.Boolean.FALSE else null
-          }
-        },
-      )
-      .asInstanceOf[Logger]
+    val logger = new StubLogger(levelsEnabled = false, onLog = () => ())
 
     val forced = new AtomicInteger(0)
     val log = Log[IO](logger).withMdc(Log.Mdc.Eager("source" -> "spec"))
@@ -287,6 +263,35 @@ class LogSpec extends AnyFunSuite with Matchers {
 }
 
 object LogSpec {
+
+  /**
+   * Reports every level as `levelsEnabled` and funnels every logging call into `onLog`, which is
+   * free to throw. `AbstractLogger` leaves the level check to the caller, matching what `Log.apply`
+   * does.
+   */
+  class StubLogger(levelsEnabled: Boolean, onLog: () => Unit) extends AbstractLogger {
+
+    protected def getFullyQualifiedCallerName: String = getClass.getName
+
+    protected def handleNormalizedLoggingCall(
+      level: Level,
+      marker: Marker,
+      messagePattern: String,
+      arguments: Array[Object],
+      throwable: Throwable,
+    ): Unit = onLog()
+
+    def isTraceEnabled: Boolean = levelsEnabled
+    def isTraceEnabled(marker: Marker): Boolean = levelsEnabled
+    def isDebugEnabled: Boolean = levelsEnabled
+    def isDebugEnabled(marker: Marker): Boolean = levelsEnabled
+    def isInfoEnabled: Boolean = levelsEnabled
+    def isInfoEnabled(marker: Marker): Boolean = levelsEnabled
+    def isWarnEnabled: Boolean = levelsEnabled
+    def isWarnEnabled(marker: Marker): Boolean = levelsEnabled
+    def isErrorEnabled: Boolean = levelsEnabled
+    def isErrorEnabled(marker: Marker): Boolean = levelsEnabled
+  }
 
   val logOf: LogOf[StateT] = {
     val logOf = new LogOf[StateT] {

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
@@ -1,12 +1,20 @@
 package com.evolutiongaming.catshelper
 
 import cats.Id
+import cats.Show
 import cats.arrow.FunctionK
-import cats.effect.IO
+import cats.effect.kernel.Ref
+import cats.effect.std.Console
+import cats.effect.{IO, SyncIO}
 import com.evolutiongaming.catshelper.IOSuite._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.slf4j.{Logger, MDC}
 
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.nio.charset.Charset
+import java.util.concurrent.atomic.AtomicInteger
+import scala.jdk.CollectionConverters._
 import scala.util.control.NoStackTrace
 
 class LogSpec extends AnyFunSuite with Matchers {
@@ -147,6 +155,41 @@ class LogSpec extends AnyFunSuite with Matchers {
     io.unsafeRunSync() shouldEqual null
   }
 
+  ignore("logging does not disturb the caller MDC when the logger throws") {
+    val logger = Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[Logger]),
+        new InvocationHandler {
+          def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+            method.getName match {
+              case "isInfoEnabled" => java.lang.Boolean.TRUE
+              case "info" => throw Error
+              case _ => null
+            }
+          }
+        },
+      )
+      .asInstanceOf[Logger]
+
+    def contextMap = Option(MDC.getCopyOfContextMap).fold(Map.empty[String, String])(_.asScala.toMap)
+
+    // MDC is thread-local, so the logging must run on the thread that reads it back.
+    // `SyncIO` guarantees that, `IO.unsafeRunSync` would run on a compute worker instead.
+    val backup = MDC.getCopyOfContextMap
+    val (before, after) = try {
+      MDC.clear()
+      MDC.put("caller", "value")
+      val before = contextMap
+      Log[SyncIO](logger).info("message", Log.Mdc.Eager("logged" -> "value")).attempt.unsafeRunSync()
+      (before, contextMap)
+    } finally {
+      if (backup == null) MDC.clear() else MDC.setContextMap(backup)
+    }
+
+    after shouldEqual before
+  }
+
   test("LogOf.log") {
     implicit val instance = logOf
 
@@ -170,6 +213,76 @@ class LogSpec extends AnyFunSuite with Matchers {
       _ <- log.error("error msg", new RuntimeException("error exception"), mdc)
     } yield {}
     io.unsafeRunSync()
+  }
+
+  ignore("Log.console labels errors as ERROR") {
+    val result = for {
+      lines <- Ref[IO].of(List.empty[String])
+      _ <- {
+        implicit val console: Console[IO] = new Console[IO] {
+          def readLineWithCharset(charset: Charset) = IO.raiseError[String](new UnsupportedOperationException)
+          def print[A](
+            a: A,
+          )(implicit
+            show: Show[A],
+          ) = IO.unit
+          def println[A](
+            a: A,
+          )(implicit
+            show: Show[A],
+          ) = IO.unit
+          def error[A](
+            a: A,
+          )(implicit
+            show: Show[A],
+          ) = IO.unit
+          def errorln[A](
+            a: A,
+          )(implicit
+            show: Show[A],
+          ) = lines.update(show.show(a) :: _)
+        }
+
+        Log.console[IO]("source").error("message")
+      }
+      lines <- lines.get
+    } yield {
+      lines should contain("ERROR\tsource: message")
+    }
+
+    result.unsafeRunSync()
+  }
+
+  ignore("withMdc does not force a lazy MDC when the level is disabled") {
+    val logger = Proxy
+      .newProxyInstance(
+        getClass.getClassLoader,
+        Array(classOf[Logger]),
+        new InvocationHandler {
+          def invoke(proxy: Any, method: Method, args: Array[AnyRef]): AnyRef = {
+            val name = method.getName
+            if (name.startsWith("is") && name.endsWith("Enabled")) java.lang.Boolean.FALSE else null
+          }
+        },
+      )
+      .asInstanceOf[Logger]
+
+    val forced = new AtomicInteger(0)
+    val log = Log[IO](logger).withMdc(Log.Mdc.Eager("source" -> "spec"))
+    val effect = log.trace("message", Log.Mdc.Lazy("key" -> { forced.incrementAndGet(); "value" }))
+
+    forced.get() shouldEqual 0
+    effect.unsafeRunSync()
+    forced.get() shouldEqual 0
+  }
+
+  ignore("lazy and eager MDC with the same content are equal") {
+    val lazyMdc = Log.Mdc.Lazy("key" -> "value")
+    val eagerMdc = Log.Mdc.Eager("key" -> "value")
+
+    lazyMdc.hashCode shouldEqual eagerMdc.hashCode
+    lazyMdc shouldEqual eagerMdc
+    eagerMdc shouldEqual lazyMdc
   }
 }
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/LogSpec.scala
@@ -155,7 +155,7 @@ class LogSpec extends AnyFunSuite with Matchers {
     io.unsafeRunSync() shouldEqual null
   }
 
-  ignore("logging does not disturb the caller MDC when the logger throws") {
+  test("logging does not disturb the caller MDC when the logger throws") {
     val logger = Proxy
       .newProxyInstance(
         getClass.getClassLoader,
@@ -215,7 +215,7 @@ class LogSpec extends AnyFunSuite with Matchers {
     io.unsafeRunSync()
   }
 
-  ignore("Log.console labels errors as ERROR") {
+  test("Log.console labels errors as ERROR") {
     val result = for {
       lines <- Ref[IO].of(List.empty[String])
       _ <- {
@@ -253,7 +253,7 @@ class LogSpec extends AnyFunSuite with Matchers {
     result.unsafeRunSync()
   }
 
-  ignore("withMdc does not force a lazy MDC when the level is disabled") {
+  test("withMdc does not force a lazy MDC when the level is disabled") {
     val logger = Proxy
       .newProxyInstance(
         getClass.getClassLoader,
@@ -276,7 +276,7 @@ class LogSpec extends AnyFunSuite with Matchers {
     forced.get() shouldEqual 0
   }
 
-  ignore("lazy and eager MDC with the same content are equal") {
+  test("lazy and eager MDC with the same content are equal") {
     val lazyMdc = Log.Mdc.Lazy("key" -> "value")
     val eagerMdc = Log.Mdc.Eager("key" -> "value")
 


### PR DESCRIPTION
`withMDC` has no `try/finally`. When the logger throws, the restore is skipped and the worker thread keeps the temporary MDC. The caller context is lost, and later log lines on that thread carry the wrong data.

`mapMdc` applies `f(mdc)` while the effect is built, which resolves a `LazyContext`. So `withMdc(...).trace(msg, Mdc.Lazy("k" -> expensive))` runs `expensive` with TRACE off. That is the cost `Mdc.Lazy` exists to avoid.

`LazyContext.hashCode` unwraps the thunk, `equals` does not. `Mdc.Lazy("a" -> "b") == Mdc.Eager("a" -> "b")` is false while the hash codes match. Hash containers break, and a test comparing the two forms fails with two values that print the same.

`Log.console` prints `ERRROR`.

The lazy MDC fix and the equality fix ship together. `mapMdc` starts handing the logger a `LazyContext` where it handed an `EagerContext`, and three existing MDC tests keep passing only because equality compares content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected console error messages to display the proper `ERROR` label.
  * Logging now reliably restores existing diagnostic context after failures.
  * Improved consistency when comparing diagnostic context values.
  * Prevented unnecessary diagnostic-context processing when logging is disabled.
* **Tests**
  * Added coverage for error handling, console output, deferred processing, and context consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->