### PR TITLE
Fix O(n²) batch fill in GroupWithin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import Dependencies.*
+import com.typesafe.tools.mima.core.*
 import sbtversionpolicy.Compatibility.BinaryCompatible
 
 def crossSettings[T](scalaVersion: String, if3: Seq[T], if2: Seq[T]) = {
@@ -80,6 +81,9 @@ lazy val core = project
       scalaVersion.value,
       if3 = Seq("-Ykind-projector:underscores", "-language:implicitConversions"),
       if2 = List("-Xsource:3", "-P:kind-projector:underscore-placeholders"),
+    ),
+    mimaBinaryIssueFilters ++= Seq(
+      ProblemFilters.exclude[Problem]("com.evolutiongaming.catshelper.GroupWithin#S#3#Full*"),
     ),
   )
   .dependsOn(

--- a/core/src/main/scala/com/evolutiongaming/catshelper/GroupWithin.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/GroupWithin.scala
@@ -44,11 +44,11 @@ object GroupWithin {
         object S {
           def empty: S = Empty
           def stopped: S = Stopped
-          def full(as: Nel[A], timestamp: Long): S = Full(as, timestamp)
+          def full(a: A, timestamp: Long): S = Full(Nel.of(a), timestamp, 1)
 
           case object Empty extends S
           case object Stopped extends S
-          final case class Full(as: Nel[A], timestamp: Long) extends S
+          final case class Full(as: Nel[A], timestamp: Long, count: Int) extends S
         }
 
         if (settings.size <= 1 || settings.delay <= 0.millis) {
@@ -85,9 +85,10 @@ object GroupWithin {
                     a <- ref.modify {
                       case s: S.Full =>
                         val as = a :: s.as
-                        if (as.size >= settings.size) (S.empty, consume(as))
-                        else (s.copy(as = as), void)
-                      case S.Empty => (S.full(Nel.of(a), t), startTimer(t))
+                        val count = s.count + 1
+                        if (count >= settings.size) (S.empty, consume(as))
+                        else (s.copy(as = as, count = count), void)
+                      case S.Empty => (S.full(a, t), startTimer(t))
                       case S.Stopped => (S.stopped, void)
                     }
                     a <- a

--- a/core/src/test/scala/com/evolutiongaming/catshelper/GroupWithinSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/GroupWithinSpec.scala
@@ -26,6 +26,11 @@ class GroupWithinSpec extends AnyFreeSpec with Matchers {
     `collect until size reached`[IO]
   }
 
+  "collect until size reached, size > 2" in ioTest { env =>
+    import env._
+    `collect until size reached, size > 2`[IO]
+  }
+
   "collect until deadline reached" in ioTest { env =>
     import env._
     `collect until deadline reached`[IO]
@@ -70,6 +75,27 @@ class GroupWithinSpec extends AnyFreeSpec with Matchers {
       a <- ref.get
     } yield {
       a shouldEqual List(Nel.of(3, 4), Nel.of(1, 2))
+    }
+  }
+
+  private def `collect until size reached, size > 2`[F[_]: Temporal] = {
+    val settings = GroupWithin.Settings(delay = 1.minute, size = 3)
+    for {
+      ref <- Ref[F].of(List.empty[Nel[Int]])
+      groupWithin = GroupWithin[F].apply[Int](settings) { a => ref.update { a :: _ } }
+      _ <- groupWithin.use { enqueue =>
+        for {
+          _ <- enqueue(1)
+          _ <- enqueue(2)
+          _ <- enqueue(3)
+          _ <- enqueue(4)
+          _ <- enqueue(5)
+          _ <- enqueue(6)
+        } yield {}
+      }
+      a <- ref.get
+    } yield {
+      a shouldEqual List(Nel.of(4, 5, 6), Nel.of(1, 2, 3))
     }
   }
 


### PR DESCRIPTION
GroupWithin recomputed NonEmptyList.size on every enqueued element to check the batch threshold, making batch fill O(n²). Adds a running `count` field to `S.Full` for an O(1) check instead. No behavior change, covered by a new size = 3 test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item grouping so batches consistently respect the configured size limit.
  * Improved handling of groups containing more than two items, ensuring items are emitted in complete, correctly sized batches.
  * Ensured grouping remains accurate when processing items incrementally.

* **Tests**
  * Added coverage for grouping six items into two batches of three.
  * Verified that larger batch sizes produce complete, non-empty groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->