### PR TITLE
Document the serial queues and record the cancellation defect

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/Serial.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/Serial.scala
@@ -5,17 +5,34 @@ import cats.effect.kernel.{Deferred, Ref}
 import cats.effect.syntax.all._
 import cats.syntax.all._
 
+/**
+ * Runs tasks strictly one after another, in submission order.
+ *
+ * Unlike a mutex-based approach the caller does not wait for its turn: `apply` only registers the
+ * task and returns. Tasks run on a background fiber, started on demand and released when the queue
+ * drains.
+ *
+ * Registration is uncancelable: once `apply` returns, the task runs even if the caller is canceled.
+ * Canceling the inner effect stops the waiting, not the task.
+ *
+ * See [[SerialKey]] for per-key serialization and [[SerialRef]] for serialized access to a value.
+ */
 trait Serial[F[_]] {
 
   /**
    * @return
-   *   outer F[_] is about adding `fa` to the queue, inner F[_] is about `fa` being completed
+   *   outer F[_] is about adding `fa` to the queue, inner F[_] is about `fa` being completed. If
+   *   `fa` fails, the inner F[_] raises its error and the queue continues with the next task.
    */
   def apply[A](fa: F[A]): F[F[A]]
 }
 
 object Serial {
 
+  /**
+   * Pending tasks are not stored in a collection: `S.Active(task)` chains them into a single
+   * `F[Unit]` via `productR`, so enqueue cost and state size stay constant.
+   */
   def of[F[_]: Async]: F[Serial[F]] = {
 
     sealed trait S

--- a/core/src/main/scala/com/evolutiongaming/catshelper/Serial.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/Serial.scala
@@ -15,6 +15,9 @@ import cats.syntax.all._
  * Registration is uncancelable: once `apply` returns, the task runs even if the caller is canceled.
  * Canceling the inner effect stops the waiting, not the task.
  *
+ * A task that cancels itself stops the runner before it advances the queue, so every task behind it
+ * waits forever, see https://github.com/evolution-gaming/cats-helper/issues/404
+ *
  * See [[SerialKey]] for per-key serialization and [[SerialRef]] for serialized access to a value.
  */
 trait Serial[F[_]] {
@@ -30,8 +33,9 @@ trait Serial[F[_]] {
 object Serial {
 
   /**
-   * Pending tasks are not stored in a collection: `S.Active(task)` chains them into a single
-   * `F[Unit]` via `productR`, so enqueue cost and state size stay constant.
+   * Pending tasks are chained into a single `F[Unit]` via `productR` rather than held in a
+   * collection, so the runner claims the whole backlog in one `ref.modify` instead of one per task.
+   * Enqueue stays O(1). Memory grows with the backlog either way.
    */
   def of[F[_]: Async]: F[Serial[F]] = {
 

--- a/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
@@ -6,17 +6,38 @@ import cats.effect.syntax.all._
 import cats.implicits._
 import cats.{Applicative, Hash}
 
+/**
+ * Runs tasks serially per key: tasks with the same key run one after another, in submission order,
+ * tasks with different keys run in parallel.
+ *
+ * As in [[Serial]], the caller does not wait for its turn: `apply` only registers the task, and
+ * registration is uncancelable. See [[SerParQueue]] when keyless tasks that order against all keys
+ * are needed as well.
+ */
 trait SerialKey[F[_], -K] {
 
+  /**
+   * @return
+   *   outer F[_] is about adding `task` to the queue of `key`, inner F[_] is about `task` being
+   *   completed. If `task` fails, the inner F[_] raises its error and the queue continues with the
+   *   next task.
+   */
   def apply[A](key: K)(task: F[A]): F[F[A]]
 }
 
 object SerialKey {
 
+  /**
+   * No serialization: runs the task in place.
+   */
   def empty[F[_]: Applicative, K]: SerialKey[F, K] = new SerialKey[F, K] {
     def apply[A](key: K)(task: F[A]) = task.map { _.pure[F] }
   }
 
+  /**
+   * Keys are hash-partitioned into one instance per available core (see [[Partitions]]), to spread
+   * contention over several `Ref`s instead of a single one.
+   */
   def of[F[_]: Concurrent: Runtime, K: Hash]: F[SerialKey[F, K]] = {
     for {
       cores <- Runtime[F].availableCores
@@ -32,6 +53,11 @@ object SerialKey {
     }
   }
 
+  /**
+   * State per key: `None` - a task runs and nothing is pending, `Some(task)` - a task runs and
+   * `task` (pending tasks chained via `productR`) follows it. The entry is removed once the key
+   * drains, so the map holds in-flight keys only.
+   */
   private def of1[F[_]: Concurrent, K]: F[SerialKey[F, K]] = {
 
     val void = ().pure[F]

--- a/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
@@ -13,6 +13,10 @@ import cats.{Applicative, Hash}
  * As in [[Serial]], the caller does not wait for its turn: `apply` only registers the task, and
  * registration is uncancelable. See [[SerParQueue]] when keyless tasks that order against all keys
  * are needed as well.
+ *
+ * A task that cancels itself stops the runner of its key before it advances the queue, so every
+ * task behind it on that key waits forever, see
+ * https://github.com/evolution-gaming/cats-helper/issues/404
  */
 trait SerialKey[F[_], -K] {
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/SerParQueueTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/SerParQueueTest.scala
@@ -127,6 +127,8 @@ class SerParQueueTest extends AsyncFunSuite with Matchers {
     result.run()
   }
 
+  // Ignored: a canceled task wedges the queue for good. Both fixes considered so far cost more
+  // than the defect, see https://github.com/evolution-gaming/cats-helper/issues/404
   ignore("advance the queue after a task cancels") {
     val result = List(none[Int], 0.some).traverse_ { key =>
       for {

--- a/core/src/test/scala/com/evolutiongaming/catshelper/SerParQueueTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/SerParQueueTest.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.catshelper
 
 import cats.Parallel
 import cats.effect.kernel.Async
-import cats.effect.kernel.{Deferred, Ref}
+import cats.effect.kernel.{Deferred, Outcome, Ref}
 import cats.effect.syntax.all._
 import cats.effect.{Clock, Concurrent, IO, Sync, Temporal}
 import cats.syntax.all._
@@ -124,6 +124,23 @@ class SerParQueueTest extends AsyncFunSuite with Matchers {
       b <- threadId
       _ <- IO { a shouldEqual b }
     } yield {}
+    result.run()
+  }
+
+  ignore("advance the queue after a task cancels") {
+    val result = List(none[Int], 0.some).traverse_ { key =>
+      for {
+        queue <- SerParQueue.of[IO, Int]
+        canceled <- queue(key)(IO.canceled)
+        next <- queue(key)(IO.pure(1))
+        value <- next
+        _ = value shouldEqual 1
+        fiber <- canceled.start
+        outcome <- fiber.join
+        _ = outcome should matchPattern { case Outcome.Canceled() => }
+      } yield {}
+    }
+
     result.run()
   }
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/SerialKeyTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/SerialKeyTest.scala
@@ -3,7 +3,7 @@ package com.evolutiongaming.catshelper
 import cats.Hash
 import cats.data.{NonEmptyList => Nel}
 import cats.effect.kernel.Async
-import cats.effect.kernel.{Deferred, Ref}
+import cats.effect.kernel.{Deferred, Outcome, Ref}
 import cats.effect.syntax.all._
 import cats.effect.{Clock, Concurrent, IO, Sync, Temporal}
 import cats.syntax.all._
@@ -53,6 +53,21 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       b <- threadId
       _ <- IO { a shouldEqual b }
     } yield {}
+    result.run()
+  }
+
+  ignore("advance a key after a task cancels") {
+    val result = for {
+      serial <- SerialKey.of[IO, String]
+      canceled <- serial("key")(IO.canceled)
+      next <- serial("key")(IO.pure(1))
+      value <- next
+      _ = value shouldEqual 1
+      fiber <- canceled.start
+      outcome <- fiber.join
+      _ = outcome should matchPattern { case Outcome.Canceled() => }
+    } yield {}
+
     result.run()
   }
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/SerialKeyTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/SerialKeyTest.scala
@@ -56,6 +56,8 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
     result.run()
   }
 
+  // Ignored: a canceled task wedges the queue for good. Both fixes considered so far cost more
+  // than the defect, see https://github.com/evolution-gaming/cats-helper/issues/404
   ignore("advance a key after a task cancels") {
     val result = for {
       serial <- SerialKey.of[IO, String]

--- a/core/src/test/scala/com/evolutiongaming/catshelper/SerialTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/SerialTest.scala
@@ -24,6 +24,8 @@ class SerialTest extends AsyncFunSuite with Matchers {
     asyncBoundary[IO].run()
   }
 
+  // Ignored: a canceled task wedges the queue for good. Both fixes considered so far cost more
+  // than the defect, see https://github.com/evolution-gaming/cats-helper/issues/404
   ignore("advance the queue after a task cancels") {
     val result = for {
       serial <- Serial.of[IO]

--- a/core/src/test/scala/com/evolutiongaming/catshelper/SerialTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/SerialTest.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.catshelper
 
 import cats.effect.kernel.Async
-import cats.effect.kernel.{Deferred, Ref}
+import cats.effect.kernel.{Deferred, Outcome, Ref}
 import cats.effect.{IO, Sync}
 import cats.implicits._
 import com.evolutiongaming.catshelper.IOSuite._
@@ -22,6 +22,21 @@ class SerialTest extends AsyncFunSuite with Matchers {
 
   test("asyncBoundary (nice to have)") {
     asyncBoundary[IO].run()
+  }
+
+  ignore("advance the queue after a task cancels") {
+    val result = for {
+      serial <- Serial.of[IO]
+      canceled <- serial(IO.canceled)
+      next <- serial(IO.pure(1))
+      value <- next
+      _ = value shouldEqual 1
+      fiber <- canceled.start
+      outcome <- fiber.join
+      _ = outcome should matchPattern { case Outcome.Canceled() => }
+    } yield {}
+
+    result.run()
   }
 
   private def serial[F[_]: Async] = {


### PR DESCRIPTION
`Serial` and `SerialKey` had no scaladoc. Their guarantees were only readable off the state
machine, and some of them matter to a caller: `apply` registers the task and returns rather than
waiting for a turn, registration is uncancelable, and canceling the inner effect stops the waiting
but not the task. A failed task raises to its own caller and the queue carries on. None of that was
written down anywhere.

Adds ignored test specs demonstrating the behaviour stated in https://github.com/evolution-gaming/cats-helper/issues/404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified serial task behavior, including submission order, cancellation effects, failure handling, task continuation, and lifecycle management.
  - Documented keyed queue registration, partitioning, empty-state handling, backlog processing, and memory considerations.

- **Tests**
  - Added regression coverage for canceled tasks in serial and keyed queues.
  - Verified cancellation outcomes and recorded current behavior where canceling a task can prevent later tasks from progressing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->