### PR TITLE
 Add a JMH module and a ConcurrentHashMap backed SerialKey

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -30,7 +30,8 @@ reading anything into a difference:
 | Command | `sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s .*Benchmark.*"` |
 
 Throughput in ops/s, higher is better. One `SerialKeyBenchmark` operation covers 64 tasks, so its
-scores are not comparable with the other two suites.
+scores are not comparable with the other two suites, and its rows are for
+`implementation=partitioned`.
 
 | Suite | Benchmark | keys | tasks | Score |
 | --- | --- | ---: | ---: | ---: |

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,56 @@
+# Benchmarks
+
+JMH benchmarks for `cats-helper`. The module is not part of the aggregate build, so `sbt test` and
+CI never run it. Run them by hand:
+
+```sh
+sbt benchmark/Jmh/run                                                       # everything
+sbt "benchmark/Jmh/run com.evolutiongaming.catshelper.SerialKeyBenchmark"   # one suite
+sbt "benchmark/Jmh/run -prof gc SerialBenchmark.pipelined"                  # allocation too
+```
+
+`-f` forks, `-wi`/`-w` warmup iterations and duration, `-i`/`-r` measurement iterations and
+duration, `-p name=value` pins a `@Param`, `-rf json -rff out.json` saves results. These override
+the annotations on the class.
+
+Each suite says in its own scaladoc what it measures and why.
+
+## Baseline
+
+One measurement of the code as it stands, so a later change has something to be compared against.
+JMH scores are only comparable within one machine and one JDK, so reproduce this row before
+reading anything into a difference:
+
+| | |
+| --- | --- |
+| Commit | `c9eeb01` |
+| Machine | Apple M1 Pro, macOS 26.5.2 |
+| JDK | OpenJDK 25.0.3 |
+| Scala | 2.13.18 |
+| Command | `sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s .*Benchmark.*"` |
+
+Throughput in ops/s, higher is better.
+
+| Suite | Benchmark | keys | tasks | Score |
+| --- | --- | ---: | ---: | ---: |
+| `SerialBenchmark` | `pipelined` | | 1 | 100 335 ± 1 513 |
+| `SerialBenchmark` | `pipelined` | | 16 | 51 002 ± 1 941 |
+| `SerialBenchmark` | `pipelined` | | 256 | 9 297 ± 948 |
+| `SerialBenchmark` | `sequential` | | 1 | 90 810 ± 12 626 |
+| `SerialBenchmark` | `sequential` | | 16 | 37 408 ± 5 721 |
+| `SerialBenchmark` | `sequential` | | 256 | 3 151 ± 56 |
+| `SerialKeyBenchmark` | `singleThread` | 1 | | 100 411 ± 5 469 |
+| `SerialKeyBenchmark` | `singleThread` | 8 | | 97 471 ± 13 026 |
+| `SerialKeyBenchmark` | `singleThread` | 64 | | 95 699 ± 13 213 |
+| `SerialKeyBenchmark` | `eightThreads` | 1 | | 261 417 ± 12 493 |
+| `SerialKeyBenchmark` | `eightThreads` | 8 | | 277 859 ± 11 734 |
+| `SerialKeyBenchmark` | `eightThreads` | 64 | | 273 137 ± 24 661 |
+| `SerParQueueBenchmark` | `keyed` | 1 | | 261 167 ± 20 741 |
+| `SerParQueueBenchmark` | `keyed` | 8 | | 272 437 ± 26 488 |
+| `SerParQueueBenchmark` | `keyed` | 64 | | 274 495 ± 23 539 |
+| `SerParQueueBenchmark` | `keyless` | 1 | | 260 309 ± 17 944 |
+| `SerParQueueBenchmark` | `keyless` | 8 | | 255 453 ± 23 083 |
+| `SerParQueueBenchmark` | `keyless` | 64 | | 258 685 ± 11 854 |
+
+Replace this table when the baseline moves. The before and after of a single change belong in the
+description of the pull request that makes it.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -28,59 +28,65 @@ reading anything into a difference:
 | Scala | 2.13.18 |
 | Command | `sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s .*Benchmark.*"` |
 
-Throughput in ops/s, higher is better. One `SerialKeyBenchmark` operation covers 64 tasks, so its
-scores are not comparable with the other two suites.
+Throughput in ops/s, higher is better. One operation covers 64 tasks in `SerialKeyBenchmark`,
+`SerParQueueBenchmark` and `SerParQueueKeylessBenchmark`, and `tasks` tasks in `SerialBenchmark`,
+so scores are only comparable within a suite.
 
 ### SerialBenchmark
 
 | Benchmark | tasks | Score |
 | --- | ---: | ---: |
-| `pipelined` | 1 | 103 279 ± 2 096 |
-| `pipelined` | 16 | 56 270 ± 514 |
-| `pipelined` | 256 | 9 483 ± 213 |
-| `sequential` | 1 | 107 029 ± 3 921 |
-| `sequential` | 16 | 39 737 ± 751 |
-| `sequential` | 256 | 3 164 ± 51 |
+| `pipelined` | 1 | 86 990 ± 12 361 |
+| `pipelined` | 16 | 52 630 ± 10 047 |
+| `pipelined` | 256 | 8 765 ± 163 |
+| `sequential` | 1 | 93 134 ± 24 153 |
+| `sequential` | 16 | 38 073 ± 5 130 |
+| `sequential` | 256 | 3 100 ± 69 |
+
+The `tasks = 1` rows carry a wide error because one operation is a single task, so the measurement
+is dominated by the handoff between the calling thread and the compute pool. Read the 256 rows for
+a stable figure.
 
 ### SerialKeyBenchmark
 
 | Benchmark | implementation | keys | Score |
 | --- | --- | ---: | ---: |
-| `singleThread` | `partitioned` | 1 | 25 601 ± 126 |
-| `singleThread` | `partitioned` | 8 | 22 984 ± 796 |
-| `singleThread` | `partitioned` | 64 | 20 294 ± 1 120 |
-| `singleThread` | `partitioned` | 1024 | 18 957 ± 816 |
-| `singleThread` | `partitioned` | 100000 | 19 340 ± 1 079 |
-| `singleThread` | `concurrentHashMap` | 1 | 22 591 ± 545 |
-| `singleThread` | `concurrentHashMap` | 8 | 20 846 ± 788 |
-| `singleThread` | `concurrentHashMap` | 64 | 18 714 ± 449 |
-| `singleThread` | `concurrentHashMap` | 1024 | 18 171 ± 1 512 |
-| `singleThread` | `concurrentHashMap` | 100000 | 18 546 ± 800 |
-| `eightThreads` | `partitioned` | 1 | 52 111 ± 847 |
-| `eightThreads` | `partitioned` | 8 | 71 944 ± 2 663 |
-| `eightThreads` | `partitioned` | 64 | 58 871 ± 3 718 |
-| `eightThreads` | `partitioned` | 1024 | 53 437 ± 5 839 |
-| `eightThreads` | `partitioned` | 100000 | 57 099 ± 5 584 |
-| `eightThreads` | `concurrentHashMap` | 1 | 23 805 ± 707 |
-| `eightThreads` | `concurrentHashMap` | 8 | 61 645 ± 1 607 |
-| `eightThreads` | `concurrentHashMap` | 64 | 62 234 ± 3 601 |
-| `eightThreads` | `concurrentHashMap` | 1024 | 65 154 ± 10 002 |
-| `eightThreads` | `concurrentHashMap` | 100000 | 72 369 ± 7 472 |
+| `singleThread` | `partitioned` | 1 | 25 022 ± 440 |
+| `singleThread` | `partitioned` | 8 | 23 354 ± 205 |
+| `singleThread` | `partitioned` | 64 | 20 453 ± 1 048 |
+| `singleThread` | `partitioned` | 1024 | 19 365 ± 469 |
+| `singleThread` | `partitioned` | 100000 | 18 759 ± 988 |
+| `singleThread` | `concurrentHashMap` | 1 | 22 915 ± 239 |
+| `singleThread` | `concurrentHashMap` | 8 | 21 788 ± 788 |
+| `singleThread` | `concurrentHashMap` | 64 | 18 438 ± 536 |
+| `singleThread` | `concurrentHashMap` | 1024 | 18 662 ± 889 |
+| `singleThread` | `concurrentHashMap` | 100000 | 18 675 ± 346 |
+| `eightThreads` | `partitioned` | 1 | 53 054 ± 1 509 |
+| `eightThreads` | `partitioned` | 8 | 73 448 ± 2 815 |
+| `eightThreads` | `partitioned` | 64 | 61 513 ± 2 997 |
+| `eightThreads` | `partitioned` | 1024 | 54 878 ± 2 855 |
+| `eightThreads` | `partitioned` | 100000 | 57 109 ± 7 931 |
+| `eightThreads` | `concurrentHashMap` | 1 | 23 814 ± 265 |
+| `eightThreads` | `concurrentHashMap` | 8 | 62 344 ± 1 928 |
+| `eightThreads` | `concurrentHashMap` | 64 | 63 100 ± 2 733 |
+| `eightThreads` | `concurrentHashMap` | 1024 | 66 238 ± 5 096 |
+| `eightThreads` | `concurrentHashMap` | 100000 | 72 660 ± 8 971 |
 
 ### SerParQueueBenchmark
 
 | Benchmark | keys | Score |
 | --- | ---: | ---: |
-| `keyed` | 1 | 262 039 ± 10 864 |
-| `keyed` | 8 | 278 905 ± 18 188 |
-| `keyed` | 64 | 276 485 ± 11 631 |
-| `keyed` | 256 | 275 357 ± 4 119 |
-| `keyed` | 1024 | 278 134 ± 7 996 |
-| `keyless` | 1 | 264 736 ± 14 070 |
-| `keyless` | 8 | 260 776 ± 4 472 |
-| `keyless` | 64 | 263 170 ± 3 920 |
-| `keyless` | 256 | 262 007 ± 7 791 |
-| `keyless` | 1024 | 263 735 ± 5 393 |
+| `keyed` | 1 | 53 873 ± 4 647 |
+| `keyed` | 8 | 40 759 ± 2 542 |
+| `keyed` | 64 | 29 588 ± 1 185 |
+| `keyed` | 256 | 22 670 ± 378 |
+| `keyed` | 1024 | 21 189 ± 566 |
+
+### SerParQueueKeylessBenchmark
+
+| Benchmark | Score |
+| --- | ---: |
+| `keyless` | 53 441 ± 1 124 |
 
 Replace this table when the baseline moves. The before and after of a single change belong in the
 description of the pull request that makes it.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -29,28 +29,37 @@ reading anything into a difference:
 | Scala | 2.13.18 |
 | Command | `sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s .*Benchmark.*"` |
 
-Throughput in ops/s, higher is better.
+Throughput in ops/s, higher is better. One `SerialKeyBenchmark` operation covers 64 tasks, so its
+scores are not comparable with the other two suites.
 
 | Suite | Benchmark | keys | tasks | Score |
 | --- | --- | ---: | ---: | ---: |
-| `SerialBenchmark` | `pipelined` | | 1 | 100 335 ± 1 513 |
-| `SerialBenchmark` | `pipelined` | | 16 | 51 002 ± 1 941 |
-| `SerialBenchmark` | `pipelined` | | 256 | 9 297 ± 948 |
-| `SerialBenchmark` | `sequential` | | 1 | 90 810 ± 12 626 |
-| `SerialBenchmark` | `sequential` | | 16 | 37 408 ± 5 721 |
-| `SerialBenchmark` | `sequential` | | 256 | 3 151 ± 56 |
-| `SerialKeyBenchmark` | `singleThread` | 1 | | 100 411 ± 5 469 |
-| `SerialKeyBenchmark` | `singleThread` | 8 | | 97 471 ± 13 026 |
-| `SerialKeyBenchmark` | `singleThread` | 64 | | 95 699 ± 13 213 |
-| `SerialKeyBenchmark` | `eightThreads` | 1 | | 261 417 ± 12 493 |
-| `SerialKeyBenchmark` | `eightThreads` | 8 | | 277 859 ± 11 734 |
-| `SerialKeyBenchmark` | `eightThreads` | 64 | | 273 137 ± 24 661 |
-| `SerParQueueBenchmark` | `keyed` | 1 | | 261 167 ± 20 741 |
-| `SerParQueueBenchmark` | `keyed` | 8 | | 272 437 ± 26 488 |
-| `SerParQueueBenchmark` | `keyed` | 64 | | 274 495 ± 23 539 |
-| `SerParQueueBenchmark` | `keyless` | 1 | | 260 309 ± 17 944 |
-| `SerParQueueBenchmark` | `keyless` | 8 | | 255 453 ± 23 083 |
-| `SerParQueueBenchmark` | `keyless` | 64 | | 258 685 ± 11 854 |
+| `SerialBenchmark` | `pipelined` | | 1 | 100 718 ± 2 722 |
+| `SerialBenchmark` | `pipelined` | | 16 | 54 267 ± 641 |
+| `SerialBenchmark` | `pipelined` | | 256 | 9 564 ± 404 |
+| `SerialBenchmark` | `sequential` | | 1 | 105 192 ± 1 540 |
+| `SerialBenchmark` | `sequential` | | 16 | 38 812 ± 7 096 |
+| `SerialBenchmark` | `sequential` | | 256 | 3 073 ± 16 |
+| `SerialKeyBenchmark` | `singleThread` | 1 | | 25 270 ± 288 |
+| `SerialKeyBenchmark` | `singleThread` | 8 | | 23 208 ± 626 |
+| `SerialKeyBenchmark` | `singleThread` | 64 | | 18 494 ± 2 394 |
+| `SerialKeyBenchmark` | `singleThread` | 256 | | 19 046 ± 549 |
+| `SerialKeyBenchmark` | `singleThread` | 1024 | | 18 798 ± 427 |
+| `SerialKeyBenchmark` | `eightThreads` | 1 | | 48 252 ± 815 |
+| `SerialKeyBenchmark` | `eightThreads` | 8 | | 71 149 ± 3 429 |
+| `SerialKeyBenchmark` | `eightThreads` | 64 | | 59 476 ± 6 671 |
+| `SerialKeyBenchmark` | `eightThreads` | 256 | | 53 899 ± 1 685 |
+| `SerialKeyBenchmark` | `eightThreads` | 1024 | | 52 410 ± 7 503 |
+| `SerParQueueBenchmark` | `keyed` | 1 | | 257 192 ± 8 653 |
+| `SerParQueueBenchmark` | `keyed` | 8 | | 270 765 ± 18 719 |
+| `SerParQueueBenchmark` | `keyed` | 64 | | 273 563 ± 15 662 |
+| `SerParQueueBenchmark` | `keyed` | 256 | | 273 664 ± 9 267 |
+| `SerParQueueBenchmark` | `keyed` | 1024 | | 273 597 ± 16 786 |
+| `SerParQueueBenchmark` | `keyless` | 1 | | 258 808 ± 6 657 |
+| `SerParQueueBenchmark` | `keyless` | 8 | | 257 395 ± 11 988 |
+| `SerParQueueBenchmark` | `keyless` | 64 | | 259 078 ± 8 660 |
+| `SerParQueueBenchmark` | `keyless` | 256 | | 259 765 ± 10 935 |
+| `SerParQueueBenchmark` | `keyless` | 1024 | | 257 541 ± 8 078 |
 
 Replace this table when the baseline moves. The before and after of a single change belong in the
 description of the pull request that makes it.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -35,52 +35,52 @@ scores are not comparable with the other two suites.
 
 | Benchmark | tasks | Score |
 | --- | ---: | ---: |
-| `pipelined` | 1 | 96 508 ± 5 220 |
-| `pipelined` | 16 | 54 023 ± 1 812 |
-| `pipelined` | 256 | 7 458 ± 7 190 |
-| `sequential` | 1 | 86 605 ± 35 975 |
-| `sequential` | 16 | 37 816 ± 3 827 |
-| `sequential` | 256 | 3 105 ± 715 |
+| `pipelined` | 1 | 103 279 ± 2 096 |
+| `pipelined` | 16 | 56 270 ± 514 |
+| `pipelined` | 256 | 9 483 ± 213 |
+| `sequential` | 1 | 107 029 ± 3 921 |
+| `sequential` | 16 | 39 737 ± 751 |
+| `sequential` | 256 | 3 164 ± 51 |
 
 ### SerialKeyBenchmark
 
 | Benchmark | implementation | keys | Score |
 | --- | --- | ---: | ---: |
-| `singleThread` | `partitioned` | 1 | 23 947 ± 1 022 |
-| `singleThread` | `partitioned` | 8 | 22 043 ± 2 606 |
-| `singleThread` | `partitioned` | 64 | 17 829 ± 4 302 |
-| `singleThread` | `partitioned` | 1024 | 17 614 ± 3 646 |
-| `singleThread` | `partitioned` | 100000 | 17 550 ± 2 468 |
-| `singleThread` | `concurrentHashMap` | 1 | 21 794 ± 1 850 |
-| `singleThread` | `concurrentHashMap` | 8 | 18 783 ± 2 611 |
-| `singleThread` | `concurrentHashMap` | 64 | 17 872 ± 1 567 |
-| `singleThread` | `concurrentHashMap` | 1024 | 17 043 ± 2 191 |
-| `singleThread` | `concurrentHashMap` | 100000 | 15 626 ± 3 463 |
-| `eightThreads` | `partitioned` | 1 | 47 040 ± 9 770 |
-| `eightThreads` | `partitioned` | 8 | 68 526 ± 2 895 |
-| `eightThreads` | `partitioned` | 64 | 55 896 ± 6 863 |
-| `eightThreads` | `partitioned` | 1024 | 51 997 ± 7 414 |
-| `eightThreads` | `partitioned` | 100000 | 52 924 ± 5 862 |
-| `eightThreads` | `concurrentHashMap` | 1 | 23 518 ± 365 |
-| `eightThreads` | `concurrentHashMap` | 8 | 60 812 ± 1 341 |
-| `eightThreads` | `concurrentHashMap` | 64 | 59 884 ± 7 417 |
-| `eightThreads` | `concurrentHashMap` | 1024 | 63 851 ± 9 909 |
-| `eightThreads` | `concurrentHashMap` | 100000 | 65 669 ± 16 950 |
+| `singleThread` | `partitioned` | 1 | 25 601 ± 126 |
+| `singleThread` | `partitioned` | 8 | 22 984 ± 796 |
+| `singleThread` | `partitioned` | 64 | 20 294 ± 1 120 |
+| `singleThread` | `partitioned` | 1024 | 18 957 ± 816 |
+| `singleThread` | `partitioned` | 100000 | 19 340 ± 1 079 |
+| `singleThread` | `concurrentHashMap` | 1 | 22 591 ± 545 |
+| `singleThread` | `concurrentHashMap` | 8 | 20 846 ± 788 |
+| `singleThread` | `concurrentHashMap` | 64 | 18 714 ± 449 |
+| `singleThread` | `concurrentHashMap` | 1024 | 18 171 ± 1 512 |
+| `singleThread` | `concurrentHashMap` | 100000 | 18 546 ± 800 |
+| `eightThreads` | `partitioned` | 1 | 52 111 ± 847 |
+| `eightThreads` | `partitioned` | 8 | 71 944 ± 2 663 |
+| `eightThreads` | `partitioned` | 64 | 58 871 ± 3 718 |
+| `eightThreads` | `partitioned` | 1024 | 53 437 ± 5 839 |
+| `eightThreads` | `partitioned` | 100000 | 57 099 ± 5 584 |
+| `eightThreads` | `concurrentHashMap` | 1 | 23 805 ± 707 |
+| `eightThreads` | `concurrentHashMap` | 8 | 61 645 ± 1 607 |
+| `eightThreads` | `concurrentHashMap` | 64 | 62 234 ± 3 601 |
+| `eightThreads` | `concurrentHashMap` | 1024 | 65 154 ± 10 002 |
+| `eightThreads` | `concurrentHashMap` | 100000 | 72 369 ± 7 472 |
 
 ### SerParQueueBenchmark
 
 | Benchmark | keys | Score |
 | --- | ---: | ---: |
-| `keyed` | 1 | 269 360 ± 23 980 |
-| `keyed` | 8 | 273 713 ± 6 436 |
-| `keyed` | 64 | 283 340 ± 16 538 |
-| `keyed` | 256 | 275 698 ± 30 912 |
-| `keyed` | 1024 | 269 992 ± 79 635 |
-| `keyless` | 1 | 261 262 ± 8 141 |
-| `keyless` | 8 | 267 356 ± 10 629 |
-| `keyless` | 64 | 258 759 ± 9 000 |
-| `keyless` | 256 | 264 028 ± 8 576 |
-| `keyless` | 1024 | 218 094 ± 203 352 |
+| `keyed` | 1 | 262 039 ± 10 864 |
+| `keyed` | 8 | 278 905 ± 18 188 |
+| `keyed` | 64 | 276 485 ± 11 631 |
+| `keyed` | 256 | 275 357 ± 4 119 |
+| `keyed` | 1024 | 278 134 ± 7 996 |
+| `keyless` | 1 | 264 736 ± 14 070 |
+| `keyless` | 8 | 260 776 ± 4 472 |
+| `keyless` | 64 | 263 170 ± 3 920 |
+| `keyless` | 256 | 262 007 ± 7 791 |
+| `keyless` | 1024 | 263 735 ± 5 393 |
 
 Replace this table when the baseline moves. The before and after of a single change belong in the
 description of the pull request that makes it.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -23,44 +23,64 @@ reading anything into a difference:
 
 | | |
 | --- | --- |
-| Commit | `c9eeb01` |
 | Machine | Apple M1 Pro, macOS 26.5.2 |
 | JDK | OpenJDK 25.0.3 |
 | Scala | 2.13.18 |
 | Command | `sbt "benchmark/Jmh/run -f 1 -wi 5 -i 5 -w 2s -r 2s .*Benchmark.*"` |
 
 Throughput in ops/s, higher is better. One `SerialKeyBenchmark` operation covers 64 tasks, so its
-scores are not comparable with the other two suites, and its rows are for
-`implementation=partitioned`.
+scores are not comparable with the other two suites.
 
-| Suite | Benchmark | keys | tasks | Score |
-| --- | --- | ---: | ---: | ---: |
-| `SerialBenchmark` | `pipelined` | | 1 | 100 718 ± 2 722 |
-| `SerialBenchmark` | `pipelined` | | 16 | 54 267 ± 641 |
-| `SerialBenchmark` | `pipelined` | | 256 | 9 564 ± 404 |
-| `SerialBenchmark` | `sequential` | | 1 | 105 192 ± 1 540 |
-| `SerialBenchmark` | `sequential` | | 16 | 38 812 ± 7 096 |
-| `SerialBenchmark` | `sequential` | | 256 | 3 073 ± 16 |
-| `SerialKeyBenchmark` | `singleThread` | 1 | | 25 270 ± 288 |
-| `SerialKeyBenchmark` | `singleThread` | 8 | | 23 208 ± 626 |
-| `SerialKeyBenchmark` | `singleThread` | 64 | | 18 494 ± 2 394 |
-| `SerialKeyBenchmark` | `singleThread` | 256 | | 19 046 ± 549 |
-| `SerialKeyBenchmark` | `singleThread` | 1024 | | 18 798 ± 427 |
-| `SerialKeyBenchmark` | `eightThreads` | 1 | | 48 252 ± 815 |
-| `SerialKeyBenchmark` | `eightThreads` | 8 | | 71 149 ± 3 429 |
-| `SerialKeyBenchmark` | `eightThreads` | 64 | | 59 476 ± 6 671 |
-| `SerialKeyBenchmark` | `eightThreads` | 256 | | 53 899 ± 1 685 |
-| `SerialKeyBenchmark` | `eightThreads` | 1024 | | 52 410 ± 7 503 |
-| `SerParQueueBenchmark` | `keyed` | 1 | | 257 192 ± 8 653 |
-| `SerParQueueBenchmark` | `keyed` | 8 | | 270 765 ± 18 719 |
-| `SerParQueueBenchmark` | `keyed` | 64 | | 273 563 ± 15 662 |
-| `SerParQueueBenchmark` | `keyed` | 256 | | 273 664 ± 9 267 |
-| `SerParQueueBenchmark` | `keyed` | 1024 | | 273 597 ± 16 786 |
-| `SerParQueueBenchmark` | `keyless` | 1 | | 258 808 ± 6 657 |
-| `SerParQueueBenchmark` | `keyless` | 8 | | 257 395 ± 11 988 |
-| `SerParQueueBenchmark` | `keyless` | 64 | | 259 078 ± 8 660 |
-| `SerParQueueBenchmark` | `keyless` | 256 | | 259 765 ± 10 935 |
-| `SerParQueueBenchmark` | `keyless` | 1024 | | 257 541 ± 8 078 |
+### SerialBenchmark
+
+| Benchmark | tasks | Score |
+| --- | ---: | ---: |
+| `pipelined` | 1 | 96 508 ± 5 220 |
+| `pipelined` | 16 | 54 023 ± 1 812 |
+| `pipelined` | 256 | 7 458 ± 7 190 |
+| `sequential` | 1 | 86 605 ± 35 975 |
+| `sequential` | 16 | 37 816 ± 3 827 |
+| `sequential` | 256 | 3 105 ± 715 |
+
+### SerialKeyBenchmark
+
+| Benchmark | implementation | keys | Score |
+| --- | --- | ---: | ---: |
+| `singleThread` | `partitioned` | 1 | 23 947 ± 1 022 |
+| `singleThread` | `partitioned` | 8 | 22 043 ± 2 606 |
+| `singleThread` | `partitioned` | 64 | 17 829 ± 4 302 |
+| `singleThread` | `partitioned` | 1024 | 17 614 ± 3 646 |
+| `singleThread` | `partitioned` | 100000 | 17 550 ± 2 468 |
+| `singleThread` | `concurrentHashMap` | 1 | 21 794 ± 1 850 |
+| `singleThread` | `concurrentHashMap` | 8 | 18 783 ± 2 611 |
+| `singleThread` | `concurrentHashMap` | 64 | 17 872 ± 1 567 |
+| `singleThread` | `concurrentHashMap` | 1024 | 17 043 ± 2 191 |
+| `singleThread` | `concurrentHashMap` | 100000 | 15 626 ± 3 463 |
+| `eightThreads` | `partitioned` | 1 | 47 040 ± 9 770 |
+| `eightThreads` | `partitioned` | 8 | 68 526 ± 2 895 |
+| `eightThreads` | `partitioned` | 64 | 55 896 ± 6 863 |
+| `eightThreads` | `partitioned` | 1024 | 51 997 ± 7 414 |
+| `eightThreads` | `partitioned` | 100000 | 52 924 ± 5 862 |
+| `eightThreads` | `concurrentHashMap` | 1 | 23 518 ± 365 |
+| `eightThreads` | `concurrentHashMap` | 8 | 60 812 ± 1 341 |
+| `eightThreads` | `concurrentHashMap` | 64 | 59 884 ± 7 417 |
+| `eightThreads` | `concurrentHashMap` | 1024 | 63 851 ± 9 909 |
+| `eightThreads` | `concurrentHashMap` | 100000 | 65 669 ± 16 950 |
+
+### SerParQueueBenchmark
+
+| Benchmark | keys | Score |
+| --- | ---: | ---: |
+| `keyed` | 1 | 269 360 ± 23 980 |
+| `keyed` | 8 | 273 713 ± 6 436 |
+| `keyed` | 64 | 283 340 ± 16 538 |
+| `keyed` | 256 | 275 698 ± 30 912 |
+| `keyed` | 1024 | 269 992 ± 79 635 |
+| `keyless` | 1 | 261 262 ± 8 141 |
+| `keyless` | 8 | 267 356 ± 10 629 |
+| `keyless` | 64 | 258 759 ± 9 000 |
+| `keyless` | 256 | 264 028 ± 8 576 |
+| `keyless` | 1024 | 218 094 ± 203 352 |
 
 Replace this table when the baseline moves. The before and after of a single change belong in the
 description of the pull request that makes it.

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -13,7 +13,7 @@ sbt "benchmark/Jmh/run -prof gc SerialBenchmark.pipelined"                  # al
 duration, `-p name=value` pins a `@Param`, `-rf json -rff out.json` saves results. These override
 the annotations on the class.
 
-Each suite says in its own scaladoc what it measures and why.
+Each suite says in its own Scaladoc what it measures and why.
 
 ## Baseline
 

--- a/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerParQueueBenchmark.scala
+++ b/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerParQueueBenchmark.scala
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 class SerParQueueBenchmark {
 
-  @Param(Array("1", "8", "64"))
+  @Param(Array("1", "8", "64", "256", "1024"))
   var keys: Int = 0
 
   // JMH drives state through mutable fields and lifecycle hooks, so `var` is required here.

--- a/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerParQueueBenchmark.scala
+++ b/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerParQueueBenchmark.scala
@@ -1,0 +1,55 @@
+package com.evolutiongaming.catshelper
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.TimeUnit
+
+/**
+ * Cost of putting a task through [[SerParQueue]], for both task kinds it accepts.
+ *
+ * A keyed task orders against tasks of the same key, a keyless one orders against everything, so
+ * `keyless` is the barrier case and is expected to be the slower of the two.
+ *
+ * To run: {{{sbt "benchmark/Jmh/run com.evolutiongaming.catshelper.SerParQueueBenchmark"}}}
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+class SerParQueueBenchmark {
+
+  @Param(Array("1", "8", "64"))
+  var keys: Int = 0
+
+  // JMH drives state through mutable fields and lifecycle hooks, so `var` is required here.
+  private var runtime: IORuntime = null
+  private var queue: SerParQueue[IO, Int] = null
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    runtime = IORuntime.global
+    queue = SerParQueue.of[IO, Int].unsafeRunSync()(runtime)
+  }
+
+  @Benchmark
+  @Threads(8)
+  def keyed(hole: Blackhole): Unit = {
+    val key = ThreadLocalRandom.current().nextInt(keys)
+    val result = queue(key.some) { IO.unit }.flatten
+    hole.consume(result.unsafeRunSync()(runtime))
+  }
+
+  @Benchmark
+  @Threads(8)
+  def keyless(hole: Blackhole): Unit = {
+    val result = queue(none[Int]) { IO.unit }.flatten
+    hole.consume(result.unsafeRunSync()(runtime))
+  }
+}

--- a/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerParQueueKeylessBenchmark.scala
+++ b/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerParQueueKeylessBenchmark.scala
@@ -6,20 +6,18 @@ import cats.syntax.all._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
-import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 
 /**
- * Cost of putting a keyed task through [[SerParQueue]], which orders against tasks of the same key.
+ * Cost of putting a keyless task through [[SerParQueue]], which orders against every other task.
  *
- * The keyless case has no key to vary, so it lives in [[SerParQueueKeylessBenchmark]] rather than
- * repeating once per `keys` value here.
+ * Separate from [[SerParQueueBenchmark]] because a keyless task has no key, so a `keys` parameter
+ * would only repeat the same measurement.
  *
- * One operation enqueues `tasksPerOp` tasks and awaits them all. Enqueueing a single task per
- * operation measures the handoff between the calling thread and the compute pool rather than the
- * queue, which on this workload swamps the result.
+ * One operation enqueues `tasksPerOp` tasks and awaits them all, for the reason given in
+ * [[SerParQueueBenchmark]].
  *
- * To run: {{{sbt "benchmark/Jmh/run com.evolutiongaming.catshelper.SerParQueueBenchmark"}}}
+ * To run: {{{sbt "benchmark/Jmh/run com.evolutiongaming.catshelper.SerParQueueKeylessBenchmark"}}}
  */
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.Throughput))
@@ -27,10 +25,7 @@ import java.util.concurrent.TimeUnit
 @Fork(1)
 @Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
-class SerParQueueBenchmark {
-
-  @Param(Array("1", "8", "64", "256", "1024"))
-  var keys: Int = 0
+class SerParQueueKeylessBenchmark {
 
   private val tasksPerOp = 64
 
@@ -46,11 +41,10 @@ class SerParQueueBenchmark {
 
   @Benchmark
   @Threads(8)
-  def keyed(hole: Blackhole): Unit = {
-    val random = ThreadLocalRandom.current()
+  def keyless(hole: Blackhole): Unit = {
     val result = List
-      .fill(tasksPerOp) { random.nextInt(keys) }
-      .traverse { key => queue(key.some) { IO.unit } }
+      .fill(tasksPerOp) { queue(none[Int]) { IO.unit } }
+      .sequence
       .flatMap { _.sequence_ }
     hole.consume(result.unsafeRunSync()(runtime))
   }

--- a/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerialBenchmark.scala
+++ b/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerialBenchmark.scala
@@ -1,0 +1,57 @@
+package com.evolutiongaming.catshelper
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Cost of putting a task through [[Serial]] and waiting for its result.
+ *
+ * `pipelined` registers every task before awaiting any of them, so the queue runs a chained batch.
+ * `sequential` awaits each task before registering the next, so the queue is entered from idle
+ * every time. The two exercise the queue loop and the per-task wrapper in different proportions.
+ *
+ * To run: {{{sbt "benchmark/Jmh/run com.evolutiongaming.catshelper.SerialBenchmark"}}}
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+class SerialBenchmark {
+
+  @Param(Array("1", "16", "256"))
+  var tasks: Int = 0
+
+  // JMH drives state through mutable fields and lifecycle hooks, so `var` is required here.
+  private var runtime: IORuntime = null
+  private var serial: Serial[IO] = null
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    runtime = IORuntime.global
+    serial = Serial.of[IO].unsafeRunSync()(runtime)
+  }
+
+  @Benchmark
+  def pipelined(hole: Blackhole): Unit = {
+    val result = List
+      .fill(tasks) { serial(IO.unit) }
+      .sequence
+      .flatMap { _.sequence_ }
+    hole.consume(result.unsafeRunSync()(runtime))
+  }
+
+  @Benchmark
+  def sequential(hole: Blackhole): Unit = {
+    val result = List
+      .fill(tasks) { serial(IO.unit).flatten }
+      .sequence_
+    hole.consume(result.unsafeRunSync()(runtime))
+  }
+}

--- a/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerialKeyBenchmark.scala
+++ b/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerialKeyBenchmark.scala
@@ -12,8 +12,8 @@ import java.util.concurrent.TimeUnit
 /**
  * Cost of putting a task through [[SerialKey]], across backing stores and contention levels.
  *
- * `keys` is the contention knob. `keys = 1` puts every thread on one key, which is the worst case,
- * larger counts spread the load.
+ * `keys` is the contention knob. `keys = 1` puts every thread on one key, larger counts spread the
+ * load over more of them. `implementation` picks between the two factories `SerialKey` offers.
  *
  * One operation enqueues `tasksPerOp` tasks and awaits them all. Enqueueing a single task per
  * operation measures the handoff between the calling thread and the compute pool rather than the
@@ -29,8 +29,11 @@ import java.util.concurrent.TimeUnit
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 class SerialKeyBenchmark {
 
-  @Param(Array("1", "8", "64", "256", "1024"))
+  @Param(Array("1", "8", "64", "1024", "100000"))
   var keys: Int = 0
+
+  @Param(Array("partitioned", "concurrentHashMap"))
+  var implementation: String = ""
 
   private val tasksPerOp = 64
 
@@ -41,7 +44,12 @@ class SerialKeyBenchmark {
   @Setup(Level.Trial)
   def setup(): Unit = {
     runtime = IORuntime.global
-    serialKey = SerialKey.of[IO, Int].unsafeRunSync()(runtime)
+    val of = implementation match {
+      case "partitioned" => SerialKey.of[IO, Int]
+      case "concurrentHashMap" => SerialKey.ofConcurrentHashMap[IO, Int]
+      case other => throw new IllegalArgumentException(s"unknown implementation $other")
+    }
+    serialKey = of.unsafeRunSync()(runtime)
   }
 
   private def enqueueAndAwait(hole: Blackhole): Unit = {

--- a/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerialKeyBenchmark.scala
+++ b/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerialKeyBenchmark.scala
@@ -1,0 +1,55 @@
+package com.evolutiongaming.catshelper
+
+import cats.effect.IO
+import cats.effect.unsafe.IORuntime
+import org.openjdk.jmh.annotations._
+import org.openjdk.jmh.infra.Blackhole
+
+import java.util.concurrent.ThreadLocalRandom
+import java.util.concurrent.TimeUnit
+
+/**
+ * Cost of putting a task through [[SerialKey]], with the key count as the contention knob.
+ *
+ * [[SerialKey.of]] hash-partitions keys into one [[SerialKey]] per available core, each holding its
+ * own `Ref`, to spread contention. `keys = 1` puts every thread on one key and therefore on one
+ * partition, which is the worst case. Larger key counts spread the load over more partitions.
+ * Compare the two columns to see what the partitioning buys.
+ *
+ * To run: {{{sbt "benchmark/Jmh/run com.evolutiongaming.catshelper.SerialKeyBenchmark"}}}
+ */
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+class SerialKeyBenchmark {
+
+  @Param(Array("1", "8", "64"))
+  var keys: Int = 0
+
+  // JMH drives state through mutable fields and lifecycle hooks, so `var` is required here.
+  private var runtime: IORuntime = null
+  private var serialKey: SerialKey[IO, Int] = null
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    runtime = IORuntime.global
+    serialKey = SerialKey.of[IO, Int].unsafeRunSync()(runtime)
+  }
+
+  private def enqueueAndAwait(hole: Blackhole): Unit = {
+    val key = ThreadLocalRandom.current().nextInt(keys)
+    val result = serialKey(key) { IO.unit }.flatten
+    hole.consume(result.unsafeRunSync()(runtime))
+  }
+
+  @Benchmark
+  @Threads(1)
+  def singleThread(hole: Blackhole): Unit = enqueueAndAwait(hole)
+
+  @Benchmark
+  @Threads(8)
+  def eightThreads(hole: Blackhole): Unit = enqueueAndAwait(hole)
+}

--- a/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerialKeyBenchmark.scala
+++ b/benchmark/src/main/scala/com/evolutiongaming/catshelper/SerialKeyBenchmark.scala
@@ -2,6 +2,7 @@ package com.evolutiongaming.catshelper
 
 import cats.effect.IO
 import cats.effect.unsafe.IORuntime
+import cats.syntax.all._
 import org.openjdk.jmh.annotations._
 import org.openjdk.jmh.infra.Blackhole
 
@@ -9,12 +10,14 @@ import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.TimeUnit
 
 /**
- * Cost of putting a task through [[SerialKey]], with the key count as the contention knob.
+ * Cost of putting a task through [[SerialKey]], across backing stores and contention levels.
  *
- * [[SerialKey.of]] hash-partitions keys into one [[SerialKey]] per available core, each holding its
- * own `Ref`, to spread contention. `keys = 1` puts every thread on one key and therefore on one
- * partition, which is the worst case. Larger key counts spread the load over more partitions.
- * Compare the two columns to see what the partitioning buys.
+ * `keys` is the contention knob. `keys = 1` puts every thread on one key, which is the worst case,
+ * larger counts spread the load.
+ *
+ * One operation enqueues `tasksPerOp` tasks and awaits them all. Enqueueing a single task per
+ * operation measures the handoff between the calling thread and the compute pool rather than the
+ * queue, which on this workload swamps the result with noise.
  *
  * To run: {{{sbt "benchmark/Jmh/run com.evolutiongaming.catshelper.SerialKeyBenchmark"}}}
  */
@@ -26,8 +29,10 @@ import java.util.concurrent.TimeUnit
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 class SerialKeyBenchmark {
 
-  @Param(Array("1", "8", "64"))
+  @Param(Array("1", "8", "64", "256", "1024"))
   var keys: Int = 0
+
+  private val tasksPerOp = 64
 
   // JMH drives state through mutable fields and lifecycle hooks, so `var` is required here.
   private var runtime: IORuntime = null
@@ -40,8 +45,11 @@ class SerialKeyBenchmark {
   }
 
   private def enqueueAndAwait(hole: Blackhole): Unit = {
-    val key = ThreadLocalRandom.current().nextInt(keys)
-    val result = serialKey(key) { IO.unit }.flatten
+    val random = ThreadLocalRandom.current()
+    val result = List
+      .fill(tasksPerOp) { random.nextInt(keys) }
+      .traverse { key => serialKey(key) { IO.unit } }
+      .flatMap { _.sequence_ }
     hole.consume(result.unsafeRunSync()(runtime))
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -86,6 +86,24 @@ lazy val core = project
     testkit % Test,
   )
 
+// Not aggregated, so `sbt test` and CI never run it. See benchmark/README.md.
+lazy val benchmark = project
+  .enablePlugins(JmhPlugin)
+  .settings(
+    commonSettings,
+    name := "cats-helper-benchmark",
+    publish / skip := true,
+    publishArtifact := false,
+    crossScalaVersions := Seq("2.13.18"),
+    scalacOptions ++= Seq("-Xsource:3"),
+    libraryDependencies ++= Seq(
+      compilerPlugin(("org.typelevel" % "kind-projector" % "0.13.4").cross(CrossVersion.full)),
+    ),
+  )
+  .dependsOn(
+    core,
+  )
+
 lazy val logback = project
   .settings(
     commonSettings,

--- a/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
@@ -1,7 +1,8 @@
 package com.evolutiongaming.catshelper
 
 import cats.effect.Concurrent
-import cats.effect.kernel.{Deferred, Ref}
+import cats.effect.kernel.{Async, Deferred, Ref}
+import cats.effect.std.MapRef
 import cats.effect.syntax.all._
 import cats.implicits._
 import cats.{Applicative, Hash}
@@ -112,6 +113,83 @@ object SerialKey {
                   a <- d.get
                   a <- a.liftTo[F]
                 } yield a
+            }
+          }
+        }
+      }
+  }
+
+  /**
+   * Same guarantees as [[of]], with the per-key state in a `ConcurrentHashMap` instead of
+   * hash-partitioned `Ref`s of immutable maps.
+   *
+   * Which of the two is faster depends on how the keys are used. At eight threads this one is about
+   * 1.35x faster when keys are almost always distinct, and about half the speed when every thread
+   * lands on one key. Without concurrency this one is a few percent slower at every key count.
+   *
+   * An update here touches one entry, while [[of]] rebuilds an immutable map, which is what pays
+   * off once keys are spread out. On a single hot key `ConcurrentHashMap` locks the bin while `Ref`
+   * does a lock-free compare and set, which is what costs.
+   *
+   * So prefer this one for high cardinality keys such as a session or request id, and [[of]] for a
+   * small set of keys that stay busy.
+   *
+   * Keys are compared by `hashCode` and `equals` rather than by a cats `Hash`.
+   */
+  def ofConcurrentHashMap[F[_]: Async, K]: F[SerialKey[F, K]] = {
+
+    val void = ().pure[F]
+
+    type Task = F[Unit]
+
+    /**
+     * State of a key that has a task running. A key with no task running has no entry at all, so
+     * the absent case is `None` from the `MapRef` rather than a member here.
+     */
+    sealed trait KeyState
+
+    object KeyState {
+
+      /**
+       * Nothing is queued behind the running task.
+       */
+      case object Running extends KeyState
+
+      /**
+       * `tasksChain` is queued behind the running task, chained in submission order.
+       */
+      final case class Pending(tasksChain: Task) extends KeyState
+    }
+
+    MapRef
+      .ofConcurrentHashMap[F, K, KeyState]()
+      .map { mapRef =>
+        def start(key: K, task: Task): F[Unit] = {
+          task
+            .tailRecM { task =>
+              task *> mapRef(key).modify {
+                case Some(KeyState.Pending(tasksChain)) => (KeyState.Running.some, tasksChain.asLeft[Unit])
+                case Some(KeyState.Running) => (none, ().asRight[Task])
+                case None => (none, ().asRight[Task])
+              }
+            }
+            .start
+            .void
+        }
+
+        new SerialKey[F, K] {
+          def apply[A](key: K)(task: F[A]) = {
+            Concurrent[F].uncancelable { _ =>
+              for {
+                result <- Deferred[F, Either[Throwable, A]]
+                taskAttempt = task.attempt.flatMap { result.complete(_).void }
+                _ <- mapRef(key).flatModify {
+                  case None => (KeyState.Running.some, start(key, taskAttempt))
+                  case Some(KeyState.Running) => (KeyState.Pending(taskAttempt).some, void)
+                  case Some(KeyState.Pending(tasksChain)) =>
+                    (KeyState.Pending(tasksChain.productR(taskAttempt)).some, void)
+                }
+              } yield result.get.flatMap { _.liftTo[F] }
             }
           }
         }

--- a/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
@@ -166,9 +166,12 @@ object SerialKey {
           task
             .tailRecM { task =>
               task *> mapRef(key).modify {
-                case Some(KeyState.Pending(tasksChain)) => (KeyState.Running.some, tasksChain.asLeft[Unit])
-                case Some(KeyState.Running) => (none, ().asRight[Task])
-                case None => (none, ().asRight[Task])
+                case Some(KeyState.Pending(tasksChain)) =>
+                  (KeyState.Running.some, tasksChain.asLeft[Unit])
+                case Some(KeyState.Running) =>
+                  (none, ().asRight[Task])
+                case None =>
+                  (none, ().asRight[Task])
               }
             }
             .start
@@ -182,8 +185,10 @@ object SerialKey {
                 result <- Deferred[F, Either[Throwable, A]]
                 taskAttempt = task.attempt.flatMap { result.complete(_).void }
                 _ <- mapRef(key).flatModify {
-                  case None => (KeyState.Running.some, start(key, taskAttempt))
-                  case Some(KeyState.Running) => (KeyState.Pending(taskAttempt).some, void)
+                  case None =>
+                    (KeyState.Running.some, start(key, taskAttempt))
+                  case Some(KeyState.Running) =>
+                    (KeyState.Pending(taskAttempt).some, void)
                   case Some(KeyState.Pending(tasksChain)) =>
                     (KeyState.Pending(tasksChain.productR(taskAttempt)).some, void)
                 }

--- a/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
@@ -168,9 +168,7 @@ object SerialKey {
               task *> mapRef(key).modify {
                 case Some(KeyState.Pending(tasksChain)) =>
                   (KeyState.Running.some, tasksChain.asLeft[Unit])
-                case Some(KeyState.Running) =>
-                  (none, ().asRight[Task])
-                case None =>
+                case _ =>
                   (none, ().asRight[Task])
               }
             }

--- a/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/SerialKey.scala
@@ -123,16 +123,14 @@ object SerialKey {
    * Same guarantees as [[of]], with the per-key state in a `ConcurrentHashMap` instead of
    * hash-partitioned `Ref`s of immutable maps.
    *
-   * Which of the two is faster depends on how the keys are used. At eight threads this one is about
-   * 1.35x faster when keys are almost always distinct, and about half the speed when every thread
-   * lands on one key. Without concurrency this one is a few percent slower at every key count.
-   *
-   * An update here touches one entry, while [[of]] rebuilds an immutable map, which is what pays
-   * off once keys are spread out. On a single hot key `ConcurrentHashMap` locks the bin while `Ref`
-   * does a lock-free compare and set, which is what costs.
+   * Which of the two is faster depends on how the keys are used, and neither wins everywhere. An
+   * update here touches one entry, while [[of]] rebuilds an immutable map, which pays off once keys
+   * are spread out. On a single hot key `ConcurrentHashMap` locks the bin while `Ref` does a
+   * lock-free compare and set.
    *
    * So prefer this one for high cardinality keys such as a session or request id, and [[of]] for a
-   * small set of keys that stay busy.
+   * small set of keys that stay busy. `SerialKeyBenchmark` measures both, see `benchmark/README.md`
+   * for the figures.
    *
    * Keys are compared by `hashCode` and `equals` rather than by a cats `Hash`.
    */

--- a/core/src/test/scala/com/evolutiongaming/catshelper/SerialKeyTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/SerialKeyTest.scala
@@ -30,11 +30,11 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       val tasks = 200
       val result = for {
         serial <- serialKey
-        order <- Ref[IO].of(List.empty[Int])
-        awaits <- (1 to tasks).toList.traverse { index => serial("key") { order.update { index :: _ } } }
+        order <- Ref[IO].of(Vector.empty[Int])
+        awaits <- (1 to tasks).toList.traverse { index => serial("key") { order.update { _ :+ index } } }
         _ <- awaits.sequence_
         observed <- order.get
-        _ <- IO { observed.reverse shouldEqual (1 to tasks).toList }
+        _ <- IO { observed shouldEqual (1 to tasks).toVector }
       } yield {}
       result.run()
     }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/SerialKeyTest.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/SerialKeyTest.scala
@@ -20,113 +20,121 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
 
   private val error: Throwable = new RuntimeException with NoStackTrace
 
-  test("run in parallel for different keys & serially for same") {
-    val result = for {
-      q <- Queue.of[IO, String, Int]
-      da <- Deferred[IO, Int]
-      _ <- q.start("a") { da.get }
-      a <- q("a") { 1.pure[IO] }
+  private def implementations[K: Hash]: List[(String, IO[SerialKey[IO, K]])] = List(
+    "partitioned" -> SerialKey.of[IO, K],
+    "concurrentHashMap" -> SerialKey.ofConcurrentHashMap[IO, K],
+  )
 
-      db <- Deferred[IO, Int]
-      _ <- q.start("b") { db.get }
-      b <- q("b") { 1.pure[IO] }
-      _ <- db.complete(0)
-      b <- b
-      _ <- IO { b shouldEqual 1 }
-
-      _ <- da.complete(0)
-      a <- a
-      _ <- IO { a shouldEqual 1 }
-
-      rs <- q.records
-      _ <- IO { rs shouldEqual Map(("a", Nel.of(0, 1)), ("b", Nel.of(0, 1))) }
-    } yield {}
-    result.run()
-  }
-
-  test("enqueue is not async") {
-    val threadId = IO { Thread.currentThread().getId }
-    val result = for {
-      q <- Queue.of[IO, String, Int]
-      a <- threadId
-      _ <- q("a") { 1.pure[IO] }
-      b <- threadId
-      _ <- IO { a shouldEqual b }
-    } yield {}
-    result.run()
-  }
-
-  // Ignored: a canceled task wedges the queue for good. Both fixes considered so far cost more
-  // than the defect, see https://github.com/evolution-gaming/cats-helper/issues/404
-  ignore("advance a key after a task cancels") {
-    val result = for {
-      serial <- SerialKey.of[IO, String]
-      canceled <- serial("key")(IO.canceled)
-      next <- serial("key")(IO.pure(1))
-      value <- next
-      _ = value shouldEqual 1
-      fiber <- canceled.start
-      outcome <- fiber.join
-      _ = outcome should matchPattern { case Outcome.Canceled() => }
-    } yield {}
-
-    result.run()
-  }
-
-  test("run many") {
-    val tasks = 1000
-    val keys = 10
-
-    val duration = {
-      val ms = Clock[IO].monotonic.map(_.toMillis)
-      ms.map { a => ms.map { b => (b - a).millis } }
+  implementations[String].foreach { case (name, serialKey) =>
+    test(s"$name runs tasks of one key in submission order") {
+      val tasks = 200
+      val result = for {
+        serial <- serialKey
+        order <- Ref[IO].of(List.empty[Int])
+        awaits <- (1 to tasks).toList.traverse { index => serial("key") { order.update { index :: _ } } }
+        _ <- awaits.sequence_
+        observed <- order.get
+        _ <- IO { observed.reverse shouldEqual (1 to tasks).toList }
+      } yield {}
+      result.run()
     }
 
-    val result = for {
-      logOf <- LogOf.slf4j[IO]
-      log <- logOf(SerParQueueTest.getClass)
-      q <- SerParQueue.of[IO, Int]
-      d <- duration
-      a <- 0
-        .iterateForeverM { a =>
-          for {
-            _ <- q(none) { a.pure[IO] }
-            _ <- Temporal[IO].sleep(100.millis)
-          } yield a + 1
-        }
-        .background
-        .use { _ =>
-          (1 to keys)
-            .toList
-            .parTraverse { key =>
-              (0, 0.pure[IO]).tailRecM {
-                case (n, a) =>
-                  if (n > tasks) {
-                    a.asRight[(Int, IO[Int])].pure[IO]
-                  } else {
-                    for {
-                      a <- q(key.some) { n.pure[IO] }
-                    } yield {
-                      (n + 1, a).asLeft[IO[Int]]
-                    }
-                  }
-              }.flatten
-            }
-        }
-      d <- d
-      _ <- IO { log.info(s"took ${ d.toMillis }ms for $keys parallel streams with $tasks each") }
-      _ <- IO { a.distinct shouldEqual List(tasks) }
-    } yield {}
-    result.run(1.minute)
+    test(s"$name reports a task failure to its caller and keeps the key running") {
+      val result = for {
+        serial <- serialKey
+        failed <- serial("key") { error.raiseError[IO, Int] }
+        next <- serial("key") { 1.pure[IO] }
+        a <- failed.attempt
+        _ <- IO { a shouldEqual error.asLeft }
+        b <- next
+        _ <- IO { b shouldEqual 1 }
+      } yield {}
+      result.run()
+    }
+
+    test(s"$name runs different keys in parallel and one key serially") {
+      val result = for {
+        q <- Queue.of[IO, String, Int](serialKey)
+        da <- Deferred[IO, Int]
+        _ <- q.start("a") { da.get }
+        a <- q("a") { 1.pure[IO] }
+
+        db <- Deferred[IO, Int]
+        _ <- q.start("b") { db.get }
+        b <- q("b") { 1.pure[IO] }
+        _ <- db.complete(0)
+        b <- b
+        _ <- IO { b shouldEqual 1 }
+
+        _ <- da.complete(0)
+        a <- a
+        _ <- IO { a shouldEqual 1 }
+
+        rs <- q.records
+        _ <- IO { rs shouldEqual Map(("a", Nel.of(0, 1)), ("b", Nel.of(0, 1))) }
+      } yield {}
+      result.run()
+    }
+
+    test(s"$name does not make enqueue async") {
+      val threadId = IO { Thread.currentThread().getId }
+      val result = for {
+        q <- Queue.of[IO, String, Int](serialKey)
+        a <- threadId
+        _ <- q("a") { 1.pure[IO] }
+        b <- threadId
+        _ <- IO { a shouldEqual b }
+      } yield {}
+      result.run()
+    }
+
+    // Ignored: a canceled task wedges the key for good. Both fixes considered so far cost more
+    // than the defect, see https://github.com/evolution-gaming/cats-helper/issues/404
+    ignore(s"$name advances a key after a task cancels") {
+      val result = for {
+        serial <- serialKey
+        canceled <- serial("key")(IO.canceled)
+        next <- serial("key")(IO.pure(1))
+        value <- next
+        _ = value shouldEqual 1
+        fiber <- canceled.start
+        outcome <- fiber.join
+        _ = outcome should matchPattern { case Outcome.Canceled() => }
+      } yield {}
+
+      result.run()
+    }
   }
 
   for {
+    (name, serialKey) <- implementations[Int]
     key <- List(0)
   } yield {
 
-    test("run") {
+    test(s"$name runs many tasks across many keys") {
+      val tasksPerKey = 1000
+      val keyCount = 10
+
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        serial <- serialKey
+        last <- (1 to keyCount).toList.parTraverse { key =>
+          (1, 0.pure[IO])
+            .tailRecM {
+              case (n, a) =>
+                if (n > tasksPerKey) a.asRight[(Int, IO[Int])].pure[IO]
+                else serial(key) { n.pure[IO] }.map { a => (n + 1, a).asLeft[IO[Int]] }
+            }
+            .flatten
+        }
+        _ <- IO { last.distinct shouldEqual List(tasksPerKey) }
+      } yield {}
+
+      result.run(1.minute)
+    }
+
+    test(s"$name run") {
+      val result = for {
+        q <- Queue.of[IO, Int, String](serialKey)
         _ <- q.run(key, "a")
         rs <- q.records
         _ <- IO { rs shouldEqual Map((key, Nel.of("a"))) }
@@ -134,9 +142,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("run, fail") {
+    test(s"$name run, fail") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
 
         _ <- q.run(key, "a")
 
@@ -150,9 +158,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("start, add, fail, run") {
+    test(s"$name start, add, fail, run") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
 
         d <- Deferred[IO, Either[Throwable, String]]
         a <- q(key) { d.get.rethrow }
@@ -172,9 +180,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("fail, run") {
+    test(s"$name fail, run") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
 
         a <- q(key) { error.raiseError[IO, String] }
         a <- a.attempt
@@ -188,9 +196,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("start, add, add, finish, fail, run") {
+    test(s"$name start, add, add, finish, fail, run") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
 
         d <- Deferred[IO, String]
         a <- q(key) { d.get }
@@ -215,9 +223,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("run, run") {
+    test(s"$name run, run") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
 
         _ <- q.run(key, "a")
         _ <- q.run(key, "b")
@@ -228,9 +236,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("add, add, run, run") {
+    test(s"$name add, add, run, run") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
         d <- Deferred[IO, String]
         a <- q(key) { d.get }
 
@@ -250,9 +258,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("start, add, finish, run") {
+    test(s"$name start, add, finish, run") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
 
         d <- Deferred[IO, String]
         a <- q.start(key) { d.get }
@@ -273,9 +281,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("add, add, add, run, run, run") {
+    test(s"$name add, add, add, run, run, run") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
 
         d <- Deferred[IO, String]
         a <- q(key) { d.get }
@@ -301,9 +309,9 @@ class SerialKeyTest extends AsyncFunSuite with Matchers {
       result.run()
     }
 
-    test("start, add, add, finish, run, run") {
+    test(s"$name start, add, add, finish, run, run") {
       val result = for {
-        q <- Queue.of[IO, Int, String]
+        q <- Queue.of[IO, Int, String](serialKey)
 
         d <- Deferred[IO, String]
         a <- q.start(key) { d.get }
@@ -402,9 +410,9 @@ object SerialKeyTest {
 
   object Queue {
 
-    def of[F[_]: Async, K: Hash, A]: F[Queue[F, K, A]] = {
+    def of[F[_]: Async, K: Hash, A](serialKey: F[SerialKey[F, K]]): F[Queue[F, K, A]] = {
       for {
-        queue <- SerialKey.of[F, K]
+        queue <- serialKey
         records0 <- Records.of[F, K, A]
       } yield {
         new Queue[F, K, A] {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,3 +9,5 @@ addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.3.0")
+
+addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.8")


### PR DESCRIPTION
## Why the benchmark module?

Arguments about the serial queues were based on reading the code. Both fixes considered for https://github.com/evolution-gaming/cats-helper/issues/404 were rejected due to cost, neither cost was known until it was measured. As the module is not aggregated, neither `sbt test` nor CI ever run it, and the code as it stands is held in one baseline in `benchmark/README.md`.

## Why a second SerialKey?

The `SerialKey.of` function hash-partitions the keys into one `Ref[Map[K, Option[Task]]]` per core. Every enqueue and every advance rebuilds one of those maps. This is efficient when a few keys are active and the maps remain small. However, it becomes expensive when keys are spread, because the work per update increases with the number of live keys in a partition.

`ofConcurrentHashMap` maintains the same guarantees and queue loop while storing per-key state in a `ConcurrentHashMap` via `cats.effect.std.MapRef,` ensuring that an update only affects one entry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an alternative per-key serialization implementation that allows tasks for different keys to run concurrently while preserving ordering for each key.
  - Expanded coverage to validate consistent behavior across serialization implementations.

- **Documentation**
  - Added guidance for running performance benchmarks, interpreting results, and updating baseline measurements.

- **Tests**
  - Added benchmark suites covering serial execution, keyed and keyless parallel queues, contention levels, and implementation comparisons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->