### PR TITLE
Cover FeatureToggled defects with pendingUntilFixed specs, and fix the spec itself

### DIFF
--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -18,53 +18,53 @@ import scala.concurrent.duration._
 class FeatureToggledSpec extends AnyFreeSpec {
   implicit val ioRuntime: IORuntime = IORuntime.global
 
-  "end-to-end polling" in scope { s =>
-    import s._, env._
+  "end-to-end polling" in scope { scope =>
+    import scope._, env._
 
-    val d = 10.seconds
+    val pollInterval = 10.seconds
     for {
       flag <- Ref[IO].of(false)
-      ftr = FeatureToggled.polling(baseResource, flag.get, d)
+      ftr = FeatureToggled.polling(baseResource, flag.get, pollInterval)
 
       _ <- ftr.use { access =>
         def expect(
           fetchResult: Option[Int],
-          es: List[Int],
+          expectedEvents: List[Int],
         )(implicit
           pos: Position,
         ): IO[Unit] = {
           // Polling events first to make sure they are independent from access
-          (events, access.use(IO.pure)).tupled.map(_ shouldBe ((es, fetchResult))).void
+          (events, access.use(IO.pure)).tupled.map(_ shouldBe ((expectedEvents, fetchResult))).void
         }
 
         for {
-          t0 <- getTime
+          startTime <- getTime
 
           // We started in "off" state so there nothing after the first poll.
-          _ <- sleepUntil(t0 + 1.nano)
+          _ <- sleepUntil(startTime + 1.nano)
           _ <- expect(None, List())
 
           // We're "on" but the poll is yet to come in 1 ns.
           _ <- flag.set(true)
-          _ <- sleepUntil(t0 + d - 1.nano)
+          _ <- sleepUntil(startTime + pollInterval - 1.nano)
           _ <- expect(None, List())
 
           // And after the poll we're up.
-          _ <- sleepUntil(t0 + d + 1.nano)
+          _ <- sleepUntil(startTime + pollInterval + 1.nano)
           _ <- expect(Some(1), List(1))
 
           // Still up after a few polls.
-          _ <- sleepUntil(t0 + d + d - 1.nano)
+          _ <- sleepUntil(startTime + pollInterval * 2 - 1.nano)
           _ <- expect(Some(1), List(1))
 
-          // Going down.
+          // Toggling off must release the resource on the next poll.
           _ <- flag.set(false)
-          _ <- sleepUntil(t0 + d + d + 1.nano)
+          _ <- sleepUntil(startTime + pollInterval * 2 + 1.nano)
           _ <- expect(None, List(1, -1))
 
-          // And up again.
+          // And up again, with a brand new resource.
           _ <- flag.set(true)
-          _ <- sleepUntil(t0 + d + d + d + 1.nano)
+          _ <- sleepUntil(startTime + pollInterval * 3 + 1.nano)
           _ <- expect(Some(2), List(1, -1, 2))
         } yield ()
       }
@@ -78,15 +78,15 @@ class FeatureToggledSpec extends AnyFreeSpec {
     val gracePeriod = 1.minute
     type LocalScope = (Scope, Resource[IO, Option[Int]], Boolean => IO[Unit])
 
-    def localScope(f: LocalScope => IO[Unit]): Unit = scope { s =>
-      import s._, env._
+    def localScope(body: LocalScope => IO[Unit]): Unit = scope { scope =>
+      import scope._, env._
 
       for {
         toggle <- std.Queue.bounded[IO, Boolean](1).flatTap(_.offer(true))
         ftr = FeatureToggled.of(baseResource, gracePeriod)(toggle.take.flatMap(_).foreverM)
 
         _ <- ftr.use { access =>
-          IO.sleep(1.nano) *> f((s, access, toggle.offer(_)))
+          IO.sleep(1.nano) *> body.apply((scope, access, toggle.offer(_)))
         }
       } yield ()
     }
@@ -111,60 +111,60 @@ class FeatureToggledSpec extends AnyFreeSpec {
       } yield ()
     }
 
-    "keeps resource alive while in use" in localScope { ls =>
-      val (s, access, toggle) = ls
-      import s._, env._
+    "keeps resource alive while in use" in localScope {
+      case (scope, access, toggle) =>
+        import scope._, env._
 
-      val targetTime = 1.second
-      for {
-        f1 <- access.use(_ => sleepUntil(targetTime) *> events).start
+        val targetTime = 1.second
+        for {
+          holder <- access.use(_ => sleepUntil(targetTime) *> events).start
 
-        _ <- IO.sleep(1.nano)
-        _ <- toggle(false)
+          _ <- IO.sleep(1.nano)
+          _ <- toggle(false)
 
-        // Resource must become immediately unavailable for new access.
-        _ <- IO.sleep(1.nano)
-        _ <- access.use(IO.pure).timeout(1.nano).map(_ shouldBe None)
+          // Resource must become immediately unavailable for new access.
+          _ <- IO.sleep(1.nano)
+          _ <- access.use(IO.pure).timeout(1.nano).map(_ shouldBe None)
 
-        // But must be still alive while it's in use.
-        _ <- sleepUntil(targetTime - 1.nano)
-        _ <- events.map(_ shouldBe List(1))
-        _ <- f1.join.flatMap {
-          case Succeeded(value) => value.map(_ shouldBe List(1))
-          case x => fail(s"Expected outcome Succeeded but was $x")
-        }
+          // But must be still alive while it's in use.
+          _ <- sleepUntil(targetTime - 1.nano)
+          _ <- events.map(_ shouldBe List(1))
+          _ <- holder.join.flatMap {
+            case Succeeded(value) => value.map(_ shouldBe List(1))
+            case other => fail(s"Expected outcome Succeeded but was $other")
+          }
 
-        // Finally it goes down as soon as there is no usages.
-        _ <- sleepUntil(targetTime + 1.nano)
-        _ <- events.map(_ shouldBe List(1, -1))
-      } yield ()
+          // Finally it goes down as soon as there is no usages.
+          _ <- sleepUntil(targetTime + 1.nano)
+          _ <- events.map(_ shouldBe List(1, -1))
+        } yield ()
     }
 
-    "terminate resource in-use after grace period" in localScope { ls =>
-      val (s, access, toggle) = ls
-      import s._, env._
+    "terminate resource in-use after grace period" in localScope {
+      case (scope, access, toggle) =>
+        import scope._, env._
 
-      for {
-        holder <- access.use(_ => sleepUntil(gracePeriod + 1.minute)).start
+        for {
+          holder <- access.use(_ => sleepUntil(gracePeriod + 1.minute)).start
 
-        _ <- IO.sleep(1.nano)
-        _ <- toggle(false)
+          _ <- IO.sleep(1.nano)
+          _ <- toggle(false)
 
-        // Resource in-use stays alive during grace period.
-        t <- getTime
-        _ <- sleepUntil(t + gracePeriod - 1.nano)
-        _ <- events.map(_ shouldBe List(1))
+          // Resource in-use stays alive during grace period.
+          toggledOffAt <- getTime
+          _ <- sleepUntil(toggledOffAt + gracePeriod - 1.nano)
+          _ <- events.map(_ shouldBe List(1))
 
-        // And gets forcefully terminated after.
-        _ <- sleepUntil(t + gracePeriod + 1.nano)
-        _ <- events.map(_ shouldBe List(1, -1))
+          // And gets forcefully terminated after.
+          _ <- sleepUntil(toggledOffAt + gracePeriod + 1.nano)
+          _ <- events.map(_ shouldBe List(1, -1))
 
-        // A forcefully terminated client must still be able to finish its work.
-        _ <- holder.join.flatMap {
-          case Succeeded(_) => IO.unit
-          case other => fail(s"Expected outcome Succeeded but was $other")
-        }
-      } yield ()
+          // A forcefully terminated client must still be able to finish its work.
+          _ <- holder.join.flatMap {
+            case Succeeded(_) => IO.unit
+            case other => fail(s"Expected outcome Succeeded but was $other")
+          }
+        } yield ()
     }
 
     "release of the outer resource waits for the users, but no longer than the grace period" in scope { scope =>
@@ -231,7 +231,7 @@ class FeatureToggledSpec extends AnyFreeSpec {
         // The first attempt to bring the resource up fails, the following ones succeed.
         resource = Resource.eval(attempts.updateAndGet(_ + 1)).flatMap {
           case 1 => Resource.eval(IO.raiseError[Int](new RuntimeException("cannot acquire")))
-          case n => Resource.pure[IO, Int](n)
+          case attempt => Resource.pure[IO, Int](attempt)
         }
         flag <- Ref[IO].of(true)
 
@@ -293,9 +293,9 @@ class FeatureToggledSpec extends AnyFreeSpec {
 
           for {
             _ <- {
-              val one = access.use(_ => IO.cede)
-              val loop = List.fill(1000)(one).sequence_
-              List.fill(8)(loop).parSequence_
+              val useOnce = access.use(_ => IO.cede)
+              val sequentialUses = List.fill(1000)(useOnce).sequence_
+              List.fill(8)(sequentialUses).parSequence_
             }
 
             _ <- flag.set(false)
@@ -353,8 +353,8 @@ class FeatureToggledSpec extends AnyFreeSpec {
         counter <- Ref[IO].of(0)
         events <- Ref[IO].of(Queue.empty[Int])
         resource = Resource[IO, Int] {
-          val init = counter.modify(i => (i + 1, i + 1)).flatTap(i => events.update(_ enqueue i))
-          init.map(i => i -> events.update(_ enqueue -i))
+          val init = counter.modify(count => (count + 1, count + 1)).flatTap(count => events.update(_ enqueue count))
+          init.map(count => count -> events.update(_ enqueue -count))
         }
         _ <- body(Scope(env, resource, events.get.map(_.toList)))
       } yield ()
@@ -363,12 +363,12 @@ class FeatureToggledSpec extends AnyFreeSpec {
 
   private def getTime(
     implicit
-    rt: TestRuntime[IO],
-  ) = rt.getTimeSinceStart
+    testRuntime: TestRuntime[IO],
+  ) = testRuntime.getTimeSinceStart
 
   private def sleepUntil(
-    dt: FiniteDuration,
+    deadline: FiniteDuration,
   )(implicit
-    rt: TestRuntime[IO],
-  ) = rt.sleepUntil(dt)
+    testRuntime: TestRuntime[IO],
+  ) = testRuntime.sleepUntil(deadline)
 }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -18,6 +18,8 @@ import scala.concurrent.duration._
 class FeatureToggledSpec extends AnyFreeSpec {
   implicit val ioRuntime: IORuntime = IORuntime.global
 
+  private val issueUrl = "https://github.com/evolution-gaming/cats-helper/issues"
+
   "end-to-end polling" in scope { scope =>
     import scope._, env._
 
@@ -198,7 +200,7 @@ class FeatureToggledSpec extends AnyFreeSpec {
       } yield ()
     }
 
-    "expose the same resource again when the toggle goes back on while draining" in pendingUntilFixed {
+    s"expose the same resource again when the toggle goes back on while draining ($issueUrl/417)" in pendingUntilFixed {
       manualScope {
         case (scope, access, toggle) =>
           import scope._, env._
@@ -234,7 +236,7 @@ class FeatureToggledSpec extends AnyFreeSpec {
       case Right(None) => fail("the failure was swallowed: no error and no resource")
     }
 
-    "don't swallow a failure to acquire the base resource" in pendingUntilFixed {
+    s"don't swallow a failure to acquire the base resource ($issueUrl/418)" in pendingUntilFixed {
       ioTest { env =>
         import env._
 
@@ -261,7 +263,7 @@ class FeatureToggledSpec extends AnyFreeSpec {
       }
     }
 
-    "don't swallow a failure to read the flag" in pendingUntilFixed {
+    s"don't swallow a failure to read the flag ($issueUrl/419)" in pendingUntilFixed {
       ioTest { env =>
         import env._
 
@@ -325,7 +327,7 @@ class FeatureToggledSpec extends AnyFreeSpec {
       scenario.unsafeRunTimed(10.seconds) shouldBe Some(())
     }
 
-    "never hand out a resource that is already being released" in pendingUntilFixed {
+    s"never hand out a resource that is already being released ($issueUrl/416)" in pendingUntilFixed {
       val rounds = 10000
       val clientsPerRound = 4
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -198,80 +198,86 @@ class FeatureToggledSpec extends AnyFreeSpec {
       } yield ()
     }
 
-    "expose the same resource again when the toggle goes back on while draining" ignore manualScope {
-      case (scope, access, toggle) =>
-        import scope._, env._
+    "expose the same resource again when the toggle goes back on while draining" in pendingUntilFixed {
+      manualScope {
+        case (scope, access, toggle) =>
+          import scope._, env._
 
-        for {
-          // Keeps the resource in use, so that the toggle-off starts draining instead of
-          // releasing the resource right away.
-          holder <- access.use(_ => sleepUntil(10.seconds)).start
+          for {
+            // Keeps the resource in use, so that the toggle-off starts draining instead of
+            // releasing the resource right away.
+            holder <- access.use(_ => sleepUntil(10.seconds)).start
 
-          _ <- IO.sleep(1.nano)
-          _ <- toggle(false)
-          _ <- IO.sleep(1.second)
-          _ <- toggle(true)
-          _ <- IO.sleep(1.nano)
+            _ <- IO.sleep(1.nano)
+            _ <- toggle(false)
+            _ <- IO.sleep(1.second)
+            _ <- toggle(true)
+            _ <- IO.sleep(1.nano)
 
-          // The resource was never released, so it must be available again.
-          _ <- access.use(IO.pure).map(_ shouldBe Some(1))
-          _ <- events.map(_ shouldBe List(1))
+            // The resource was never released, so it must be available again.
+            _ <- access.use(IO.pure).map(_ shouldBe Some(1))
+            _ <- events.map(_ shouldBe List(1))
 
-          _ <- holder.joinWithNever
-        } yield ()
+            _ <- holder.joinWithNever
+          } yield ()
+      }
     }
   }
 
   "failure handling" - {
-    "keep trying after the base resource fails to acquire" ignore ioTest { env =>
-      import env._
+    "keep trying after the base resource fails to acquire" in pendingUntilFixed {
+      ioTest { env =>
+        import env._
 
-      for {
-        attempts <- Ref[IO].of(0)
-        // The first attempt to bring the resource up fails, the following ones succeed.
-        resource = Resource.eval(attempts.updateAndGet(_ + 1)).flatMap {
-          case 1 => Resource.eval(IO.raiseError[Int](new RuntimeException("cannot acquire")))
-          case attempt => Resource.pure[IO, Int](attempt)
-        }
-        flag <- Ref[IO].of(true)
+        for {
+          attempts <- Ref[IO].of(0)
+          // The first attempt to bring the resource up fails, the following ones succeed.
+          resource = Resource.eval(attempts.updateAndGet(_ + 1)).flatMap {
+            case 1 => Resource.eval(IO.raiseError[Int](new RuntimeException("cannot acquire")))
+            case attempt => Resource.pure[IO, Int](attempt)
+          }
+          flag <- Ref[IO].of(true)
 
-        _ <- FeatureToggled.polling(resource, flag.get, 1.second).use { access =>
-          for {
-            // The very first poll fails to bring the resource up.
-            _ <- IO.sleep(1.nano)
-            _ <- access.use(IO.pure).map(_ shouldBe None)
+          _ <- FeatureToggled.polling(resource, flag.get, 1.second).use { access =>
+            for {
+              // The very first poll fails to bring the resource up.
+              _ <- IO.sleep(1.nano)
+              _ <- access.use(IO.pure).map(_ shouldBe None)
 
-            // The next poll must try again.
-            _ <- IO.sleep(1.second)
-            _ <- access.use(IO.pure).map(_ shouldBe Some(2))
-          } yield ()
-        }
-      } yield ()
+              // The next poll must try again.
+              _ <- IO.sleep(1.second)
+              _ <- access.use(IO.pure).map(_ shouldBe Some(2))
+            } yield ()
+          }
+        } yield ()
+      }
     }
 
-    "keep polling after a failed read of the flag" ignore ioTest { env =>
-      import env._
+    "keep polling after a failed read of the flag" in pendingUntilFixed {
+      ioTest { env =>
+        import env._
 
-      for {
-        reads <- Ref[IO].of(0)
-        // The first read of the flag fails, the following ones report "on".
-        enabled = reads.updateAndGet(_ + 1).flatMap {
-          case 1 => IO.raiseError[Boolean](new RuntimeException("cannot read the flag"))
-          case _ => IO.pure(true)
-        }
+        for {
+          reads <- Ref[IO].of(0)
+          // The first read of the flag fails, the following ones report "on".
+          enabled = reads.updateAndGet(_ + 1).flatMap {
+            case 1 => IO.raiseError[Boolean](new RuntimeException("cannot read the flag"))
+            case _ => IO.pure(true)
+          }
 
-        _ <- FeatureToggled.polling(Resource.pure[IO, Int](1), enabled, 1.second).use { access =>
-          for {
-            // Nothing to see yet: the only poll so far has failed.
-            _ <- IO.sleep(1.nano)
-            _ <- access.use(IO.pure).map(_ shouldBe None)
+          _ <- FeatureToggled.polling(Resource.pure[IO, Int](1), enabled, 1.second).use { access =>
+            for {
+              // Nothing to see yet: the only poll so far has failed.
+              _ <- IO.sleep(1.nano)
+              _ <- access.use(IO.pure).map(_ shouldBe None)
 
-            // A failed poll must not stop the polling.
-            _ <- IO.sleep(1.second)
-            _ <- access.use(IO.pure).map(_ shouldBe Some(1))
-          } yield ()
-        }
-      } yield ()
+              // A failed poll must not stop the polling.
+              _ <- IO.sleep(1.second)
+              _ <- access.use(IO.pure).map(_ shouldBe Some(1))
+            } yield ()
+          }
+        } yield ()
+      }
     }
   }
 
@@ -312,8 +318,9 @@ class FeatureToggledSpec extends AnyFreeSpec {
       scenario.unsafeRunTimed(10.seconds) shouldBe Some(())
     }
 
-    "never hand out a resource that is already being released" ignore {
+    "never hand out a resource that is already being released" in pendingUntilFixed {
       val rounds = 10000
+      val clientsPerRound = 4
 
       val scenario = for {
         toggleRef <- Deferred[IO, Boolean => IO[Unit]]
@@ -328,10 +335,13 @@ class FeatureToggledSpec extends AnyFreeSpec {
             case Some(alive) => IO.cede *> alive.get.map(_ shouldBe true)
             case None => IO.unit
           }
+          val clients = List.fill(clientsPerRound)(user).parSequence_
 
           toggleRef.get.flatMap { toggle =>
-            // A client and a toggle-off racing each other, over and over again.
-            List.fill(rounds)(toggle(true) *> (user, toggle(false)).parTupled.void).sequence_
+            /* Clients and a toggle-off racing each other, over and over again. Real threads are
+             * required here: a simulated scheduler always registers the client before it runs the
+             * toggle-off, so the gap this test aims at never opens. */
+            List.fill(rounds)(toggle(true) *> (clients, toggle(false)).parTupled.void).sequence_
           }
         }
       } yield ()

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -167,6 +167,37 @@ class FeatureToggledSpec extends AnyFreeSpec {
       } yield ()
     }
 
+    "release of the outer resource waits for the users, but no longer than the grace period" in scope { scope =>
+      import scope._, env._
+
+      for {
+        toggleRef <- Deferred[IO, Boolean => IO[Unit]]
+        ftr = FeatureToggled.of(baseResource, gracePeriod)(toggle => toggleRef.complete(toggle) *> IO.never)
+        letGo <- Deferred[IO, Unit]
+
+        startedAt <- getTime
+        // The client outlives the outer resource on purpose: it is the only way to observe how
+        // long the release waits for the clients that are still around.
+        holder <- ftr.use { access =>
+          for {
+            toggle <- toggleRef.get
+            _ <- toggle(true)
+            _ <- IO.sleep(1.nano)
+            holder <- access.use(_ => letGo.get).start
+            _ <- IO.sleep(1.nano)
+          } yield holder
+        }
+        releasedAt <- getTime
+
+        // The resource is gone, and waiting for it took the whole grace period.
+        _ <- events.map(_ shouldBe List(1, -1))
+        _ = (releasedAt - startedAt) should be >= gracePeriod
+
+        _ <- letGo.complete(())
+        _ <- holder.joinWithNever
+      } yield ()
+    }
+
     "expose the same resource again when the toggle goes back on while draining" ignore manualScope {
       case (scope, access, toggle) =>
         import scope._, env._

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -259,18 +259,21 @@ class FeatureToggledSpec extends AnyFreeSpec {
           for {
             seed <- Ref[IO].of(1)
             flag <- Ref[IO].of(true)
-            r <- FeatureToggled.polling(seed.get.toResource, flag.get, 1.milli).allocated.map(_._1)
-            _ <- {
-              val one = r.use(_ => IO.cede)
-              val loop = List.fill(1000)(one).sequence_
-              List.fill(8)(loop).parSequence_
+            _ <- FeatureToggled.polling(seed.get.toResource, flag.get, 1.milli).use { access =>
+              for {
+                _ <- {
+                  val one = access.use(_ => IO.cede)
+                  val loop = List.fill(1000)(one).sequence_
+                  List.fill(8)(loop).parSequence_
+                }
+                _ <- flag.set(false)
+                _ <- IO.sleep(100.millis)
+                _ <- seed.set(2)
+                _ <- flag.set(true)
+                _ <- IO.sleep(10.millis)
+                _ <- access.use(i => IO { i shouldBe Some(2) })
+              } yield ()
             }
-            _ <- flag.set(false)
-            _ <- IO.sleep(100.millis)
-            _ <- seed.set(2)
-            _ <- flag.set(true)
-            _ <- IO.sleep(10.millis)
-            _ <- r.use(i => IO { i shouldBe Some(2) })
           } yield ()
         }
         .unsafeRunTimed(10.seconds)

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -2,7 +2,7 @@ package com.evolutiongaming.catshelper
 
 import cats.effect.implicits._
 import cats.effect.kernel.Outcome.Succeeded
-import cats.effect.kernel.Ref
+import cats.effect.kernel.{Deferred, Ref}
 import cats.effect.unsafe.IORuntime
 import cats.effect.{IO, Resource, std}
 import cats.implicits._
@@ -92,6 +92,26 @@ class FeatureToggledSpec extends AnyFreeSpec {
       } yield ()
     }
 
+    /* Same as `localScope`, but hands the toggle function itself over to a test, so that the
+     * toggle can be flipped with no scheduling in between. */
+    def manualScope(body: LocalScope => IO[Unit]): Unit = scope { scope =>
+      import scope._, env._
+
+      for {
+        toggleRef <- Deferred[IO, Boolean => IO[Unit]]
+        ftr = FeatureToggled.of(baseResource, gracePeriod)(toggle => toggleRef.complete(toggle) *> IO.never)
+
+        _ <- ftr.use { access =>
+          for {
+            toggle <- toggleRef.get
+            _ <- toggle(true)
+            _ <- IO.sleep(1.nano)
+            _ <- body.apply((scope, access, toggle))
+          } yield ()
+        }
+      } yield ()
+    }
+
     "keeps resource alive while in use" in localScope { ls =>
       val (s, access, toggle) = ls
       import s._, env._
@@ -141,6 +161,82 @@ class FeatureToggledSpec extends AnyFreeSpec {
         _ <- events.map(_ shouldBe List(1, -1))
       } yield ()
     }
+
+    "expose the same resource again when the toggle goes back on while draining" ignore manualScope {
+      case (scope, access, toggle) =>
+        import scope._, env._
+
+        for {
+          // Keeps the resource in use, so that the toggle-off starts draining instead of
+          // releasing the resource right away.
+          holder <- access.use(_ => sleepUntil(10.seconds)).start
+
+          _ <- IO.sleep(1.nano)
+          _ <- toggle(false)
+          _ <- IO.sleep(1.second)
+          _ <- toggle(true)
+          _ <- IO.sleep(1.nano)
+
+          // The resource was never released, so it must be available again.
+          _ <- access.use(IO.pure).map(_ shouldBe Some(1))
+          _ <- events.map(_ shouldBe List(1))
+
+          _ <- holder.joinWithNever
+        } yield ()
+    }
+  }
+
+  "failure handling" - {
+    "keep trying after the base resource fails to acquire" ignore ioTest { env =>
+      import env._
+
+      for {
+        attempts <- Ref[IO].of(0)
+        // The first attempt to bring the resource up fails, the following ones succeed.
+        resource = Resource.eval(attempts.updateAndGet(_ + 1)).flatMap {
+          case 1 => Resource.eval(IO.raiseError[Int](new RuntimeException("cannot acquire")))
+          case n => Resource.pure[IO, Int](n)
+        }
+        flag <- Ref[IO].of(true)
+
+        _ <- FeatureToggled.polling(resource, flag.get, 1.second).use { access =>
+          for {
+            // The very first poll fails to bring the resource up.
+            _ <- IO.sleep(1.nano)
+            _ <- access.use(IO.pure).map(_ shouldBe None)
+
+            // The next poll must try again.
+            _ <- IO.sleep(1.second)
+            _ <- access.use(IO.pure).map(_ shouldBe Some(2))
+          } yield ()
+        }
+      } yield ()
+    }
+
+    "keep polling after a failed read of the flag" ignore ioTest { env =>
+      import env._
+
+      for {
+        reads <- Ref[IO].of(0)
+        // The first read of the flag fails, the following ones report "on".
+        enabled = reads.updateAndGet(_ + 1).flatMap {
+          case 1 => IO.raiseError[Boolean](new RuntimeException("cannot read the flag"))
+          case _ => IO.pure(true)
+        }
+
+        _ <- FeatureToggled.polling(Resource.pure[IO, Int](1), enabled, 1.second).use { access =>
+          for {
+            // Nothing to see yet: the only poll so far has failed.
+            _ <- IO.sleep(1.nano)
+            _ <- access.use(IO.pure).map(_ shouldBe None)
+
+            // A failed poll must not stop the polling.
+            _ <- IO.sleep(1.second)
+            _ <- access.use(IO.pure).map(_ shouldBe Some(1))
+          } yield ()
+        }
+      } yield ()
+    }
   }
 
   "race-conditions" - {
@@ -178,6 +274,33 @@ class FeatureToggledSpec extends AnyFreeSpec {
           } yield ()
         }
         .unsafeRunTimed(10.seconds)
+    }
+
+    "never hand out a resource that is already being released" ignore {
+      val rounds = 10000
+
+      val scenario = for {
+        toggleRef <- Deferred[IO, Boolean => IO[Unit]]
+        // The resource reports whether it is still alive.
+        resource = Resource.make(Ref[IO].of(true))(_.set(false))
+        ftr = FeatureToggled.of(resource, 1.minute)(toggle => toggleRef.complete(toggle) *> IO.never)
+
+        _ <- ftr.use { access =>
+          // A client that got the resource must be able to use it: the grace period is far from
+          // being over, so nobody is allowed to release it in the meantime.
+          val user = access.use {
+            case Some(alive) => IO.cede *> alive.get.map(_ shouldBe true)
+            case None => IO.unit
+          }
+
+          toggleRef.get.flatMap { toggle =>
+            // A client and a toggle-off racing each other, over and over again.
+            List.fill(rounds)(toggle(true) *> (user, toggle(false)).parTupled.void).sequence_
+          }
+        }
+      } yield ()
+
+      scenario.unsafeRunTimed(10.seconds)
     }
   }
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -145,7 +145,7 @@ class FeatureToggledSpec extends AnyFreeSpec {
       import s._, env._
 
       for {
-        _ <- access.use(_ => sleepUntil(gracePeriod + 1.minute)).start
+        holder <- access.use(_ => sleepUntil(gracePeriod + 1.minute)).start
 
         _ <- IO.sleep(1.nano)
         _ <- toggle(false)
@@ -158,6 +158,12 @@ class FeatureToggledSpec extends AnyFreeSpec {
         // And gets forcefully terminated after.
         _ <- sleepUntil(t + gracePeriod + 1.nano)
         _ <- events.map(_ shouldBe List(1, -1))
+
+        // A forcefully terminated client must still be able to finish its work.
+        _ <- holder.join.flatMap {
+          case Succeeded(_) => IO.unit
+          case other => fail(s"Expected outcome Succeeded but was $other")
+        }
       } yield ()
     }
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -285,7 +285,8 @@ class FeatureToggledSpec extends AnyFreeSpec {
             }
           } yield ()
         }
-        .unsafeRunTimed(10.seconds)
+        // `unsafeRunTimed` reports a hang as `None` instead of failing, so the result must be checked.
+        .unsafeRunTimed(10.seconds) shouldBe Some(())
     }
 
     "never hand out a resource that is already being released" ignore {
@@ -312,7 +313,7 @@ class FeatureToggledSpec extends AnyFreeSpec {
         }
       } yield ()
 
-      scenario.unsafeRunTimed(10.seconds)
+      scenario.unsafeRunTimed(10.seconds) shouldBe Some(())
     }
   }
 

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -225,7 +225,16 @@ class FeatureToggledSpec extends AnyFreeSpec {
   }
 
   "failure handling" - {
-    "keep trying after the base resource fails to acquire" in pendingUntilFixed {
+    /* The two tests below pin down only what must not happen: a failure that leaves no trace and
+     * `access` at `None` for ever. Raising the failure to the client and recovering on a later
+     * poll are both acceptable answers, and the choice between them is still open. */
+    def expectNotSwallowed(result: Either[Throwable, Option[Int]]): Unit = result match {
+      case Left(_) => () // the failure reached the client
+      case Right(Some(_)) => () // the toggle recovered by itself
+      case Right(None) => fail("the failure was swallowed: no error and no resource")
+    }
+
+    "don't swallow a failure to acquire the base resource" in pendingUntilFixed {
       ioTest { env =>
         import env._
 
@@ -238,22 +247,21 @@ class FeatureToggledSpec extends AnyFreeSpec {
           }
           flag <- Ref[IO].of(true)
 
-          _ <- FeatureToggled.polling(resource, flag.get, 1.second).use { access =>
-            for {
-              // The very first poll fails to bring the resource up.
-              _ <- IO.sleep(1.nano)
-              _ <- access.use(IO.pure).map(_ shouldBe None)
+          result <- FeatureToggled
+            .polling(resource, flag.get, 1.second)
+            .use { access =>
+              // The first poll fails to bring the resource up, the second one is a second later.
+              IO.sleep(1.second + 1.nano) *> access.use(IO.pure).attempt
+            }
+            .attempt
+            .map(_.flatten)
 
-              // The next poll must try again.
-              _ <- IO.sleep(1.second)
-              _ <- access.use(IO.pure).map(_ shouldBe Some(2))
-            } yield ()
-          }
+          _ = expectNotSwallowed(result)
         } yield ()
       }
     }
 
-    "keep polling after a failed read of the flag" in pendingUntilFixed {
+    "don't swallow a failure to read the flag" in pendingUntilFixed {
       ioTest { env =>
         import env._
 
@@ -265,17 +273,16 @@ class FeatureToggledSpec extends AnyFreeSpec {
             case _ => IO.pure(true)
           }
 
-          _ <- FeatureToggled.polling(Resource.pure[IO, Int](1), enabled, 1.second).use { access =>
-            for {
-              // Nothing to see yet: the only poll so far has failed.
-              _ <- IO.sleep(1.nano)
-              _ <- access.use(IO.pure).map(_ shouldBe None)
+          result <- FeatureToggled
+            .polling(Resource.pure[IO, Int](1), enabled, 1.second)
+            .use { access =>
+              // The first poll fails to read the flag, the second one is a second later.
+              IO.sleep(1.second + 1.nano) *> access.use(IO.pure).attempt
+            }
+            .attempt
+            .map(_.flatten)
 
-              // A failed poll must not stop the polling.
-              _ <- IO.sleep(1.second)
-              _ <- access.use(IO.pure).map(_ shouldBe Some(1))
-            } yield ()
-          }
+          _ = expectNotSwallowed(result)
         } yield ()
       }
     }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -260,6 +260,15 @@ class FeatureToggledSpec extends AnyFreeSpec {
             seed <- Ref[IO].of(1)
             flag <- Ref[IO].of(true)
             _ <- FeatureToggled.polling(seed.get.toResource, flag.get, 1.milli).use { access =>
+              // Polling instead of sleeping for a fixed time: a loaded CI machine can need more than
+              // a few milliseconds to catch up, and that must not fail the test.
+              def awaitValue(expected: Option[Int]): IO[Unit] = {
+                access.use(IO.pure).flatMap {
+                  case value if value == expected => IO.unit
+                  case _ => IO.sleep(1.milli) *> awaitValue(expected)
+                }
+              }
+
               for {
                 _ <- {
                   val one = access.use(_ => IO.cede)
@@ -267,11 +276,11 @@ class FeatureToggledSpec extends AnyFreeSpec {
                   List.fill(8)(loop).parSequence_
                 }
                 _ <- flag.set(false)
-                _ <- IO.sleep(100.millis)
+                _ <- awaitValue(None)
+
                 _ <- seed.set(2)
                 _ <- flag.set(true)
-                _ <- IO.sleep(10.millis)
-                _ <- access.use(i => IO { i shouldBe Some(2) })
+                _ <- awaitValue(Some(2))
               } yield ()
             }
           } yield ()

--- a/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/FeatureToggledSpec.scala
@@ -13,7 +13,6 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers._
 
 import scala.collection.immutable.Queue
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 class FeatureToggledSpec extends AnyFreeSpec {
@@ -240,53 +239,40 @@ class FeatureToggledSpec extends AnyFreeSpec {
   }
 
   "race-conditions" - {
-    final class Env(
-      implicit
-      val ec: ExecutionContext,
-    )
-    val env = cats.effect.Resource {
-      IO {
-        val tp = java.util.concurrent.Executors.newFixedThreadPool(32)
-        val ec = scala.concurrent.ExecutionContext.fromExecutor(tp)
-        val env = new Env()(ec)
-        env -> IO { tp.shutdown() }
-      }
-    }
-
     "don't get stuck after multiple concurrent uses" in {
-      env
-        .use { _ =>
-          for {
-            seed <- Ref[IO].of(1)
-            flag <- Ref[IO].of(true)
-            _ <- FeatureToggled.polling(seed.get.toResource, flag.get, 1.milli).use { access =>
-              // Polling instead of sleeping for a fixed time: a loaded CI machine can need more than
-              // a few milliseconds to catch up, and that must not fail the test.
-              def awaitValue(expected: Option[Int]): IO[Unit] = {
-                access.use(IO.pure).flatMap {
-                  case value if value == expected => IO.unit
-                  case _ => IO.sleep(1.milli) *> awaitValue(expected)
-                }
-              }
+      val scenario = for {
+        seed <- Ref[IO].of(1)
+        flag <- Ref[IO].of(true)
 
-              for {
-                _ <- {
-                  val one = access.use(_ => IO.cede)
-                  val loop = List.fill(1000)(one).sequence_
-                  List.fill(8)(loop).parSequence_
-                }
-                _ <- flag.set(false)
-                _ <- awaitValue(None)
-
-                _ <- seed.set(2)
-                _ <- flag.set(true)
-                _ <- awaitValue(Some(2))
-              } yield ()
+        _ <- FeatureToggled.polling(seed.get.toResource, flag.get, 1.milli).use { access =>
+          // Polling instead of sleeping for a fixed time: a loaded CI machine can need more than
+          // a few milliseconds to catch up, and that must not fail the test.
+          def awaitValue(expected: Option[Int]): IO[Unit] = {
+            access.use(IO.pure).flatMap {
+              case value if value == expected => IO.unit
+              case _ => IO.sleep(1.milli) *> awaitValue(expected)
             }
+          }
+
+          for {
+            _ <- {
+              val one = access.use(_ => IO.cede)
+              val loop = List.fill(1000)(one).sequence_
+              List.fill(8)(loop).parSequence_
+            }
+
+            _ <- flag.set(false)
+            _ <- awaitValue(None)
+
+            _ <- seed.set(2)
+            _ <- flag.set(true)
+            _ <- awaitValue(Some(2))
           } yield ()
         }
-        // `unsafeRunTimed` reports a hang as `None` instead of failing, so the result must be checked.
-        .unsafeRunTimed(10.seconds) shouldBe Some(())
+      } yield ()
+
+      // `unsafeRunTimed` reports a hang as `None` instead of failing, so the result must be checked.
+      scenario.unsafeRunTimed(10.seconds) shouldBe Some(())
     }
 
     "never hand out a resource that is already being released" ignore {


### PR DESCRIPTION
Spec-only change. `FeatureToggled.scala` is untouched. The fixes for the defects below come in
a separate PR.

## Defects reproduced by pendingUntilFixed tests 

The commit a16dfd0f9272a0c11fa90595f1103b5633db3c6e adds four tests. All four fail against master, so they are `pendingUntilFixed`. If we agree that an issue is as described and test spec reproduces is accurately, I will open a GitHub issue for each one and include the issue reference in the test name in subsequent commits. The fix PR then removes 'pendingUntilFixed'

### never hand out a resource that is already being released

`access` reads `stateRef`, sees `Active`, and then [starts a fiber that takes the read lock](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L97-L101). `start` schedules the fibre. During this time, the management loop [can hide the state](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L117) and [acquire the write lock](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L119). This is granted immediately because no reader is registered yet and the base resource is released. The client is left holding Some(a) for a resource that is already closed, with the entire grace period still ahead of it.

The test uses a resource that reports whether it is active, with a one-minute grace period and 10,000 rounds of one client toggling off. It fails in about half a second. PureTest cannot demonstrate this: its scheduler always runs the guard fiber before the loop, so the gap never opens. Real threads are needed.

### expose the same resource again when the toggle goes back on while draining

[The loop is a single, sequential fiber](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L125). [The off-transition sets `Empty`](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L117) and then blocks on the write lock until either the last client leaves or the grace period ends. Nothing else [sets `Active`](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L112). While the loop is waiting, every access.use gets None, even though the toggle is true and the resource is alive and in use by someone else. A one-second flag flap hides the feature for the full grace period. However, the [Scaladoc](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L53-L54) promises the opposite.

An accepted alternative is to relax the Scaladoc instead and state that the resource is unavailable until the drain ends. Whichever is cheaper.

### don't swallow a failure to acquire the base resource

[`loopOnce.foreverM`](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L125) runs under [`runManaged`](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L132-L133). Nobody joins
that fiber or looks at its outcome. A single failed `ra.use` ends the loop as `Errored` and the error goes nowhere. From that point, the `stateRef` stays empty, access returns `None` forever, toggle keeps writing a value that nobody reads, and the caller of the outer use gets no signal.

The direction of the fix is open after review. Both `fail fast` and `retry` are on the table, so the test asserts only what they both satisfy: after the failure, there must be an error for either the client or a resource. If there is no error or resource failure, the test fails. The issue records both options and the trade-offs.

### don't swallow a failure to read the flag

`polling` method [passes `enabled.flatMap(toggle)` to `Schedule`](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/FeatureToggled.scala#L48), which [has no error handling](https://github.com/evolution-gaming/cats-helper/blob/0f0b09e986d6166db36c556d6916d12214e83b79/core/src/main/scala/com/evolutiongaming/catshelper/Schedule.scala#L18-L30) . One failed read kills the poll fiber and the outer fiber is kept alive by `.use(_ => never)`, so nothing reports it. The last pushed value is frozen: if it was false, the feature can never be re-enabled, if it was true, the resource stays alive even after the flag is switched off by the operators.

Same open question as above, and the test accepts either answer.

## Spec fixes

* d929dd4 `allocated.map(_._1)` dropped the release half, so two fibers, one of them polling
  every millisecond, stayed alive for the rest of the sbt fork. Uses `use` instead.
* 3694138 The concurrency test gave the poller a fixed 10 ms to catch up. That is the CI flake
  `None was not equal to Some(2)`. It polls for the expected value instead. Discovered in https://github.com/evolution-gaming/cats-helper/actions/runs/32855035614/job/97824869508
* 8ac95ec `unsafeRunTimed` reports a hang as `None` and does not throw, and the result was
  dropped. The test named "don't get stuck" passed while stuck. Both timed runs assert `Some(())`.
* 724fa9b A 32 thread pool was built and shut down, but no code ever ran on it. Removed, together
  with the fully qualified names that came with it.
* a30b386 The forcefully terminated client fiber was discarded, so a hung or failed release after
  termination was invisible. The fiber is joined and its outcome checked.
* fb412ef New passing test for the release of the outer resource: it waits for the clients that
  are still around, bounded by the grace period. That behaviour stays as it is, the test writes
  it down.
* 71bf616 Names: `d`, `es`, `f1`, `t0`, `t`, `x`, `rt`, `dt`, `i`, `one`, `loop`, and the `s`,
  `f`, `ls` lambda parameters.
* a565eba The four defect specs run as `pendingUntilFixed` instead of `ignore`, so they report as
  pending until the fix and fail loudly once they start passing.
* 6204cf3 The two failure-handling specs assert only the minimum that both candidate fixes share.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for graceful shutdown, including resource draining, forced termination, release timing, and reactivation.
  * Added validation for concurrent access and race conditions during resource release.
  * Added scenarios covering recovery from acquisition and feature-flag read failures.
  * Improved test clarity and consistency for more reliable lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->