### PR TITLE
Fix flaky `CountLatchSpec`

### DIFF
--- a/core/src/test/scala/com/evolutiongaming/catshelper/CountLatchSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/CountLatchSpec.scala
@@ -114,7 +114,7 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
       blocked1 shouldBe true
       done shouldBe true
     }
-    io.unsafeRunSync()
+    TestControl.executeEmbed(io).unsafeRunSync()
   }
 
   test("concurrent acquire & release") {

--- a/core/src/test/scala/com/evolutiongaming/catshelper/CountLatchSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/CountLatchSpec.scala
@@ -2,6 +2,7 @@ package com.evolutiongaming.catshelper
 
 import cats.effect.IO
 import cats.effect.std.Queue
+import cats.effect.testkit.TestControl
 import cats.effect.unsafe.IORuntime
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -21,7 +22,7 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
     } yield {
       done shouldBe true
     }
-    io.unsafeRunSync()
+    TestControl.executeEmbed(io).unsafeRunSync()
   }
 
   test("init with 1") {
@@ -34,7 +35,7 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
       blocked shouldBe true
       done shouldBe true
     }
-    io.unsafeRunSync()
+    TestControl.executeEmbed(io).unsafeRunSync()
   }
 
   test("init with 0 and acquire") {
@@ -50,7 +51,7 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
       blocked shouldBe true
       done1 shouldBe true
     }
-    io.unsafeRunSync()
+    TestControl.executeEmbed(io).unsafeRunSync()
   }
 
   test("init with 1 and acquire") {
@@ -67,7 +68,7 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
       blocked1 shouldBe true
       done shouldBe true
     }
-    io.unsafeRunSync()
+    TestControl.executeEmbed(io).unsafeRunSync()
   }
 
   test("init with 0 and acquire 2") {
@@ -84,7 +85,7 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
       done0 shouldBe true
       done1 shouldBe true
     }
-    io.unsafeRunSync()
+    TestControl.executeEmbed(io).unsafeRunSync()
   }
 
   test("ignore acquire -2") {
@@ -97,7 +98,7 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
       done0 shouldBe true
       done1 shouldBe true
     }
-    io.unsafeRunSync()
+    TestControl.executeEmbed(io).unsafeRunSync()
   }
 
   test("concurrent acquire & release") {
@@ -115,7 +116,7 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
     } yield {
       done shouldBe true
     }
-    io.unsafeRunSync()
+    TestControl.executeEmbed(io).unsafeRunSync()
   }
 
 }


### PR DESCRIPTION
Fix https://github.com/evolution-gaming/cats-helper/issues/399
Root cause: The CountLatchSpec's blocked/done helpers used `timeoutTo(1 millisecond, ...)` on a real wall clock, competing with `IORuntime.global` (shared by every suite in the module) against a 1 ms timer. Under CI load/scheduler contention, this race could occasionally be lost, even for a trivially resolved latch, resulting in the reported false positive.

Fix: The tests are run under `cats.effect.testkit.TestControl.executeEmbed` instead of the real `IORuntime`. This is a single-threaded, deterministic scheduler with virtual time, so the 1 ms timeout only 'elapses' when nothing else is runnable. This correctly separates `resolves instantly` from `blocks forever` with zero dependency on real CPU scheduling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CountLatch test execution using controlled effect simulation for more reliable and deterministic test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->