### PR TITLE
Guard CountLatch.release against non-positive counts

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/CountLatch.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/CountLatch.scala
@@ -77,8 +77,7 @@ object CountLatch {
       val F = Async[F]
 
       override def acquire(n: Int): F[Unit] =
-        if (n < 1) F.unit
-        else
+        F.whenA(n >= 1) {
           state.access
             .flatMap {
               case (state, set) =>
@@ -93,17 +92,18 @@ object CountLatch {
             .iterateUntil(identity)
             .void
             .uncancelable
+        }
 
       override def release(n: Int): F[Unit] =
-        state
-          .modify {
-            case Done => Done -> F.unit
-            case Awaiting(l, await) =>
-              if (l > n) Awaiting(l - n, await) -> F.unit
-              else Done -> await.complete(()).void
-          }
-          .flatten
-          .uncancelable
+        F.whenA(n >= 1) {
+          state
+            .flatModify {
+              case Done => Done -> F.unit
+              case Awaiting(l, await) =>
+                if (l > n) Awaiting(l - n, await) -> F.unit
+                else Done -> await.complete(()).void
+            }
+        }
 
       override def await(): F[Unit] =
         state.get.flatMap {

--- a/core/src/test/scala/com/evolutiongaming/catshelper/CountLatchSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/CountLatchSpec.scala
@@ -100,6 +100,22 @@ class CountLatchSpec extends AnyFunSuite with Matchers {
     io.unsafeRunSync()
   }
 
+  test("ignore release -2") {
+    val io = for {
+      latch <- CountLatch[IO](1)
+      blocked0 <- latch.blocked
+      _ <- latch.release(-2)
+      blocked1 <- latch.blocked
+      _ <- latch.release()
+      done <- latch.done
+    } yield {
+      blocked0 shouldBe true
+      blocked1 shouldBe true
+      done shouldBe true
+    }
+    io.unsafeRunSync()
+  }
+
   test("concurrent acquire & release") {
     val times = 100
     val io = for {


### PR DESCRIPTION
Unlike acquire which ignores calls with `n < 1`, `release(n: Int)` had no lower bound check. Passing a negative to release could silently increases internal latch counter.

This change means that release now ignores `n < 1`, which is consistent with the existing behaviour for acquire. Both now use `F.whenA(n ≥ 1)` for the guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved latch behavior when acquiring or releasing with nonpositive counts.
  * Negative releases no longer incorrectly affect latch completion.

* **Tests**
  * Added coverage confirming that ignored negative releases leave the latch blocked until a valid release occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->