### PR TITLE
Make `ioToTry`'s timeout respect `uncancelable` and run finalizers

### DIFF
--- a/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
@@ -35,15 +35,14 @@ object ToTry {
    * Please think twice before using this, ideally you should not have toTry in your `pure` code
    * base!
    *
-   * Simple effects (`pure`, `delay`, `map`, `flatMap`, `attempt`, `handleErrorWith`, and therefore
-   * `Ref` operations and `Deferred#complete`) run on the calling thread and never time out. From
-   * the first `uncancelable`, `onCancel`, `Resource` or asynchronous boundary onwards the effect
-   * runs as a fiber under
+   * Simple effects (`pure`, `delay`, `map`, `flatMap`, `attempt`, `handleErrorWith`) run on the
+   * calling thread and never time out. From the first `uncancelable`, `onCancel`, `Resource` or
+   * asynchronous boundary onwards the effect runs as a fiber under
    * [[https://typelevel.org/cats-effect/docs/datatypes/io#scalatimeout IO.timeout]].
    *
    * @param timeout
-   *   applies to the part that runs as a fiber. On expiry the fiber is cancelled (not abandoned),
-   *   its finalizers run, and the result is `Failure(TimeoutException)`. Inside an
+   *   applies to the fiber part. On expiry the fiber is cancelled (not abandoned), its finalizers
+   *   run, and the result is `Failure(TimeoutException)`. Inside an
    *   [[https://typelevel.org/cats-effect/docs/typeclasses/monadcancel#uncancelable-regions uncancelable region]]
    *   there is nothing to cancel, so the effect runs to completion regardless of the timeout.
    */
@@ -75,23 +74,18 @@ object ToTry {
   }
 
   /**
-   * A `Sync[SyncIO]` whose only purpose is to control where
+   * Controls where
    * [[https://typelevel.org/cats-effect/api/3.x/cats/effect/kernel/Async.html#syncStep syncStep]]
-   * stops walking.
+   * stops walking an `IO`.
    *
-   * `syncStep` walks an `IO` node by node on the calling thread and returns whatever it could not
-   * walk as a new `IO`. How far it walks depends on `rootCancelScope` of the `Sync` instance it is
-   * given. With `SyncIO`'s own instance (scope = `Uncancelable`) it walks inside `uncancelable`
-   * regions and past `onCancel` finalizers, because `SyncIO` can never be cancelled anyway. The
-   * `IO` it returns then lacks those protections, and a timeout cancelling it skips the finalizers.
+   * `syncStep` walks an `IO` node by node on the calling thread. How far it walks depends on
+   * `rootCancelScope` of the `Sync` it is given. With `SyncIO`'s own instance (scope =
+   * `Uncancelable`) it walks inside `uncancelable` and past `onCancel`, so the returned `IO` lacks
+   * those protections. This instance reports scope = `Cancelable`, so `syncStep` stops there and
+   * returns the region whole.
    *
-   * This instance reports scope = `Cancelable`, so `syncStep` stops at `uncancelable` and
-   * `onCancel` and returns the region as is, protections included.
-   *
-   * `rootCancelScope` is the only member `syncStep` consults for this decision. Every other member
-   * delegates to `SyncIO`'s own `Sync`. The instance is unlawful (`SyncIO` cannot actually be
-   * cancelled, which the `Cancelable` scope falsely promises) and therefore private and never
-   * implicit.
+   * Only `rootCancelScope` matters; every other member delegates to `SyncIO`'s own `Sync`. The
+   * instance is unlawful (`SyncIO` cannot actually be cancelled), hence private and never implicit.
    *
    * @see
    *   [[https://typelevel.org/cats-effect/docs/typeclasses/monadcancel MonadCancel]] for

--- a/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
@@ -2,12 +2,12 @@ package com.evolutiongaming.catshelper
 
 import cats.Id
 import cats.arrow.FunctionK
-import cats.effect.IO
+import cats.effect.kernel.{CancelScope, Poll, Sync}
 import cats.effect.unsafe.IORuntime
+import cats.effect.{IO, SyncIO}
 
-import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 trait ToTry[F[_]] {
 
@@ -35,9 +35,17 @@ object ToTry {
    * Please think twice before using this, ideally you should not have toTry in your `pure` code
    * base!
    *
+   * Runs the effect on the calling thread for as long as it is pure or `delay`-shaped (`pure`,
+   * `delay`, `map`, `flatMap`, `attempt`, `handleErrorWith`, hence also `Ref` operations and
+   * `Deferred#complete`). Such effects complete inline, never touch the runtime and never time out.
+   * At the first asynchronous boundary, `uncancelable`, `onCancel` or `Resource` allocation, the
+   * rest of the effect runs as a fiber on the runtime under `IO.timeout`.
+   *
    * @param timeout
-   *   used only for computation after first seen async boundary, covering all computations onwards
-   *   in case there is no async boundary found, timeout is not used
+   *   bound on the part that runs on the runtime. It is cooperative: where the effect is cancelable
+   *   the fiber is cancelled, its finalizers run and the result is `Failure(TimeoutException)`;
+   *   inside an `uncancelable` region it waits for the region to end, so a masked effect can run
+   *   past it.
    */
   def ioToTry(
     timeout: FiniteDuration,
@@ -45,21 +53,11 @@ object ToTry {
     runtime: IORuntime,
   ): ToTry[IO] = new ToTry[IO] {
 
-    def apply[A](fa: IO[A]) = {
-
-      def error: Try[A] = Failure[A](new TimeoutException(timeout.toString()))
-
-      for {
-        a <- Try {
-          fa.syncStep(Int.MaxValue).unsafeRunSync() match {
-            case Left(computation) =>
-              computation.unsafeRunTimed(timeout)
-            case Right(value) =>
-              Some(value)
-          }
-        }
-        a <- a.fold(error) { a => Success(a) }
-      } yield a
+    def apply[A](fa: IO[A]) = Try {
+      IO.asyncForIO.syncStep[SyncIO, A](fa, Int.MaxValue)(CancelableSyncIO).unsafeRunSync() match {
+        case Right(a) => a
+        case Left(rest) => rest.timeout(timeout).unsafeRunSync()
+      }
     }
   }
 
@@ -74,5 +72,47 @@ object ToTry {
 
   implicit val tryToTry: ToTry[Try] = new ToTry[Try] {
     def apply[A](fa: Try[A]) = fa
+  }
+
+  /**
+   * `Sync[SyncIO]` that reports a `Cancelable` root scope.
+   *
+   * `syncStep` steps into `uncancelable` and `onCancel` only when the target's root scope is
+   * `Uncancelable`, handing back a remainder without its mask and finalizers. Under this instance
+   * it stops at those nodes with the remainder intact.
+   *
+   * Unlawful for `SyncIO`, hence private and never implicit. The stepper only uses `pure`,
+   * `raiseError`, `delay`, `defer`, `realTime`, `monotonic`, `map`, `flatMap`, `handleError` and
+   * `handleErrorWith`, so the wrong scope is never observed.
+   */
+  private object CancelableSyncIO extends Sync[SyncIO] {
+
+    private val F = SyncIO.syncForSyncIO
+
+    def rootCancelScope: CancelScope = CancelScope.Cancelable
+
+    def pure[A](a: A): SyncIO[A] = F.pure(a)
+
+    def raiseError[A](e: Throwable): SyncIO[A] = F.raiseError(e)
+
+    def handleErrorWith[A](fa: SyncIO[A])(f: Throwable => SyncIO[A]): SyncIO[A] = F.handleErrorWith(fa)(f)
+
+    def flatMap[A, B](fa: SyncIO[A])(f: A => SyncIO[B]): SyncIO[B] = F.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => SyncIO[Either[A, B]]): SyncIO[B] = F.tailRecM(a)(f)
+
+    def suspend[A](hint: Sync.Type)(thunk: => A): SyncIO[A] = F.suspend(hint)(thunk)
+
+    def monotonic: SyncIO[FiniteDuration] = F.monotonic
+
+    def realTime: SyncIO[FiniteDuration] = F.realTime
+
+    def forceR[A, B](fa: SyncIO[A])(fb: SyncIO[B]): SyncIO[B] = F.forceR(fa)(fb)
+
+    def uncancelable[A](body: Poll[SyncIO] => SyncIO[A]): SyncIO[A] = F.uncancelable(body)
+
+    def canceled: SyncIO[Unit] = F.canceled
+
+    def onCancel[A](fa: SyncIO[A], fin: SyncIO[Unit]): SyncIO[A] = F.onCancel(fa, fin)
   }
 }

--- a/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
@@ -35,17 +35,17 @@ object ToTry {
    * Please think twice before using this, ideally you should not have toTry in your `pure` code
    * base!
    *
-   * Runs the effect on the calling thread for as long as it is pure or `delay`-shaped (`pure`,
-   * `delay`, `map`, `flatMap`, `attempt`, `handleErrorWith`, hence also `Ref` operations and
-   * `Deferred#complete`). Such effects complete inline, never touch the runtime and never time out.
-   * At the first asynchronous boundary, `uncancelable`, `onCancel` or `Resource` allocation, the
-   * rest of the effect runs as a fiber on the runtime under `IO.timeout`.
+   * A pure or `delay`-shaped effect (`pure`, `delay`, `map`, `flatMap`, `attempt`,
+   * `handleErrorWith`, hence also `Ref` operations and `Deferred#complete`) runs on the calling
+   * thread: it never reaches the runtime and never times out. From the first asynchronous boundary,
+   * `uncancelable`, `onCancel` or `Resource` allocation onwards, the effect runs as a fiber under
+   * `IO.timeout`.
    *
    * @param timeout
-   *   bound on the part that runs on the runtime. It is cooperative: where the effect is cancelable
-   *   the fiber is cancelled, its finalizers run and the result is `Failure(TimeoutException)`;
-   *   inside an `uncancelable` region it waits for the region to end, so a masked effect can run
-   *   past it.
+   *   bound on the part that runs as a fiber. `IO.timeout` cancels rather than abandons: where the
+   *   effect is cancelable it stops, its finalizers run, and the result is
+   *   `Failure(TimeoutException)`. Cancellation waits for an `uncancelable` region to end, so an
+   *   effect can run past the timeout inside one.
    */
   def ioToTry(
     timeout: FiniteDuration,
@@ -53,7 +53,7 @@ object ToTry {
     runtime: IORuntime,
   ): ToTry[IO] = new ToTry[IO] {
 
-    def apply[A](fa: IO[A]) = Try {
+    def apply[A](fa: IO[A]): Try[A] = Try {
       IO.asyncForIO.syncStep[SyncIO, A](fa, Int.MaxValue)(CancelableSyncIO).unsafeRunSync() match {
         case Right(a) => a
         case Left(rest) => rest.timeout(timeout).unsafeRunSync()
@@ -75,44 +75,69 @@ object ToTry {
   }
 
   /**
-   * `Sync[SyncIO]` that reports a `Cancelable` root scope.
+   * `Sync[SyncIO]` that reports a `Cancelable` root scope, for `IO.syncStep` and nothing else.
    *
-   * `syncStep` steps into `uncancelable` and `onCancel` only when the target's root scope is
-   * `Uncancelable`, handing back a remainder without its mask and finalizers. Under this instance
-   * it stops at those nodes with the remainder intact.
+   * `syncStep` runs an `IO` on the calling thread as far as it can and hands back the rest as an
+   * `IO`. When the `Sync` it steps into reports an `Uncancelable` root scope, as `SyncIO`'s own
+   * instance does, `syncStep` steps inside `uncancelable` regions (masked regions, in cats-effect
+   * terms) and past `onCancel` finalizers, since neither can matter to a target that is never
+   * cancelled. What it hands back is then the inside of such a region, without the `uncancelable`
+   * around it and without the finalizers. Cancelling that, which is what a timeout does, skips the
+   * finalizers.
    *
-   * Unlawful for `SyncIO`, hence private and never implicit. The stepper only uses `pure`,
-   * `raiseError`, `delay`, `defer`, `realTime`, `monotonic`, `map`, `flatMap`, `handleError` and
-   * `handleErrorWith`, so the wrong scope is never observed.
+   * Under this instance `syncStep` stops in front of `uncancelable` and `onCancel` instead, and
+   * hands back the region whole.
+   *
+   * `rootCancelScope` is the only member `syncStep` reads to make that choice. Every other member
+   * is here to satisfy `Sync` and delegates to `SyncIO`'s own instance. The instance is unlawful,
+   * because `SyncIO#canceled` does nothing and an instance calling `SyncIO` cancelable therefore
+   * breaks the `MonadCancel` laws, so it stays private and is never implicit.
+   *
+   * @see
+   *   [[https://typelevel.org/cats-effect/docs/typeclasses/monadcancel MonadCancel]] for masked
+   *   regions, `uncancelable` and finalizers
    */
   private object CancelableSyncIO extends Sync[SyncIO] {
 
     private val F = SyncIO.syncForSyncIO
 
-    def rootCancelScope: CancelScope = CancelScope.Cancelable
+    def rootCancelScope: CancelScope =
+      CancelScope.Cancelable
 
-    def pure[A](a: A): SyncIO[A] = F.pure(a)
+    def pure[A](a: A): SyncIO[A] =
+      F.pure(a)
 
-    def raiseError[A](e: Throwable): SyncIO[A] = F.raiseError(e)
+    def raiseError[A](e: Throwable): SyncIO[A] =
+      F.raiseError(e)
 
-    def handleErrorWith[A](fa: SyncIO[A])(f: Throwable => SyncIO[A]): SyncIO[A] = F.handleErrorWith(fa)(f)
+    def handleErrorWith[A](fa: SyncIO[A])(f: Throwable => SyncIO[A]): SyncIO[A] =
+      F.handleErrorWith(fa)(f)
 
-    def flatMap[A, B](fa: SyncIO[A])(f: A => SyncIO[B]): SyncIO[B] = F.flatMap(fa)(f)
+    def flatMap[A, B](fa: SyncIO[A])(f: A => SyncIO[B]): SyncIO[B] =
+      F.flatMap(fa)(f)
 
-    def tailRecM[A, B](a: A)(f: A => SyncIO[Either[A, B]]): SyncIO[B] = F.tailRecM(a)(f)
+    def tailRecM[A, B](a: A)(f: A => SyncIO[Either[A, B]]): SyncIO[B] =
+      F.tailRecM(a)(f)
 
-    def suspend[A](hint: Sync.Type)(thunk: => A): SyncIO[A] = F.suspend(hint)(thunk)
+    def suspend[A](hint: Sync.Type)(thunk: => A): SyncIO[A] =
+      F.suspend(hint)(thunk)
 
-    def monotonic: SyncIO[FiniteDuration] = F.monotonic
+    def monotonic: SyncIO[FiniteDuration] =
+      F.monotonic
 
-    def realTime: SyncIO[FiniteDuration] = F.realTime
+    def realTime: SyncIO[FiniteDuration] =
+      F.realTime
 
-    def forceR[A, B](fa: SyncIO[A])(fb: SyncIO[B]): SyncIO[B] = F.forceR(fa)(fb)
+    def forceR[A, B](fa: SyncIO[A])(fb: SyncIO[B]): SyncIO[B] =
+      F.forceR(fa)(fb)
 
-    def uncancelable[A](body: Poll[SyncIO] => SyncIO[A]): SyncIO[A] = F.uncancelable(body)
+    def uncancelable[A](body: Poll[SyncIO] => SyncIO[A]): SyncIO[A] =
+      F.uncancelable(body)
 
-    def canceled: SyncIO[Unit] = F.canceled
+    def canceled: SyncIO[Unit] =
+      F.canceled
 
-    def onCancel[A](fa: SyncIO[A], fin: SyncIO[Unit]): SyncIO[A] = F.onCancel(fa, fin)
+    def onCancel[A](fa: SyncIO[A], fin: SyncIO[Unit]): SyncIO[A] =
+      F.onCancel(fa, fin)
   }
 }

--- a/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
@@ -35,15 +35,17 @@ object ToTry {
    * Please think twice before using this, ideally you should not have toTry in your `pure` code
    * base!
    *
-   * A pure or `delay`-shaped effect runs on the calling thread and never times out. That covers
-   * `pure`, `delay`, `map`, `flatMap`, `attempt` and `handleErrorWith`, hence `Ref` operations and
-   * `Deferred#complete` too. Everything from the first asynchronous boundary, `uncancelable` or
-   * `onCancel` runs as a fiber under `IO.timeout`. A `Resource` brings the last two with it.
+   * Simple effects (`pure`, `delay`, `map`, `flatMap`, `attempt`, `handleErrorWith`, and therefore
+   * `Ref` operations and `Deferred#complete`) run on the calling thread and never time out. From
+   * the first `uncancelable`, `onCancel`, `Resource` or asynchronous boundary onwards the effect
+   * runs as a fiber under
+   * [[https://typelevel.org/cats-effect/docs/datatypes/io#scalatimeout IO.timeout]].
    *
    * @param timeout
-   *   applies to the part that runs as a fiber. The effect is cancelled, not abandoned: it stops at
-   *   its next cancelable point, its finalizers run, and the result is `Failure(TimeoutException)`.
-   *   An `uncancelable` region has no such point, so an effect can outlive the timeout inside one.
+   *   applies to the part that runs as a fiber. On expiry the fiber is cancelled (not abandoned),
+   *   its finalizers run, and the result is `Failure(TimeoutException)`. Inside an
+   *   [[https://typelevel.org/cats-effect/docs/typeclasses/monadcancel#uncancelable-regions uncancelable region]]
+   *   there is nothing to cancel, so the effect runs to completion regardless of the timeout.
    */
   def ioToTry(
     timeout: FiniteDuration,
@@ -73,21 +75,27 @@ object ToTry {
   }
 
   /**
-   * `Sync[SyncIO]` that reports a `Cancelable` root scope, for `IO.syncStep` and nothing else.
+   * A `Sync[SyncIO]` whose only purpose is to control where
+   * [[https://typelevel.org/cats-effect/api/3.x/cats/effect/kernel/Async.html#syncStep syncStep]]
+   * stops walking.
    *
-   * `syncStep` runs an `IO` on the calling thread as far as it can and returns the rest as an `IO`.
-   * With an `Uncancelable` root scope, which `SyncIO`'s own instance reports, it steps inside
-   * `uncancelable` regions and past `onCancel` finalizers. The `IO` it returns has lost both, and a
-   * timeout that cancels it skips the finalizers. Under this instance `syncStep` stops in front of
-   * `uncancelable` and `onCancel` and returns the region whole.
+   * `syncStep` walks an `IO` node by node on the calling thread and returns whatever it could not
+   * walk as a new `IO`. How far it walks depends on `rootCancelScope` of the `Sync` instance it is
+   * given. With `SyncIO`'s own instance (scope = `Uncancelable`) it walks inside `uncancelable`
+   * regions and past `onCancel` finalizers, because `SyncIO` can never be cancelled anyway. The
+   * `IO` it returns then lacks those protections, and a timeout cancelling it skips the finalizers.
    *
-   * `rootCancelScope` is the only member `syncStep` reads for that; the others delegate to
-   * `SyncIO`'s own instance. Reporting `SyncIO` as cancelable is false, since `SyncIO#canceled`
-   * does nothing, so the instance is unlawful, private and never implicit.
+   * This instance reports scope = `Cancelable`, so `syncStep` stops at `uncancelable` and
+   * `onCancel` and returns the region as is, protections included.
+   *
+   * `rootCancelScope` is the only member `syncStep` consults for this decision. Every other member
+   * delegates to `SyncIO`'s own `Sync`. The instance is unlawful (`SyncIO` cannot actually be
+   * cancelled, which the `Cancelable` scope falsely promises) and therefore private and never
+   * implicit.
    *
    * @see
-   *   [[https://typelevel.org/cats-effect/docs/typeclasses/monadcancel MonadCancel]] for masked
-   *   regions, `uncancelable` and finalizers
+   *   [[https://typelevel.org/cats-effect/docs/typeclasses/monadcancel MonadCancel]] for
+   *   cancellation, uncancelable regions and finalizers
    */
   private object CancelableSyncIO extends Sync[SyncIO] {
 

--- a/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
+++ b/core/src/main/scala/com/evolutiongaming/catshelper/ToTry.scala
@@ -35,17 +35,15 @@ object ToTry {
    * Please think twice before using this, ideally you should not have toTry in your `pure` code
    * base!
    *
-   * A pure or `delay`-shaped effect (`pure`, `delay`, `map`, `flatMap`, `attempt`,
-   * `handleErrorWith`, hence also `Ref` operations and `Deferred#complete`) runs on the calling
-   * thread: it never reaches the runtime and never times out. From the first asynchronous boundary,
-   * `uncancelable`, `onCancel` or `Resource` allocation onwards, the effect runs as a fiber under
-   * `IO.timeout`.
+   * A pure or `delay`-shaped effect runs on the calling thread and never times out. That covers
+   * `pure`, `delay`, `map`, `flatMap`, `attempt` and `handleErrorWith`, hence `Ref` operations and
+   * `Deferred#complete` too. Everything from the first asynchronous boundary, `uncancelable` or
+   * `onCancel` runs as a fiber under `IO.timeout`. A `Resource` brings the last two with it.
    *
    * @param timeout
-   *   bound on the part that runs as a fiber. `IO.timeout` cancels rather than abandons: where the
-   *   effect is cancelable it stops, its finalizers run, and the result is
-   *   `Failure(TimeoutException)`. Cancellation waits for an `uncancelable` region to end, so an
-   *   effect can run past the timeout inside one.
+   *   applies to the part that runs as a fiber. The effect is cancelled, not abandoned: it stops at
+   *   its next cancelable point, its finalizers run, and the result is `Failure(TimeoutException)`.
+   *   An `uncancelable` region has no such point, so an effect can outlive the timeout inside one.
    */
   def ioToTry(
     timeout: FiniteDuration,
@@ -77,21 +75,15 @@ object ToTry {
   /**
    * `Sync[SyncIO]` that reports a `Cancelable` root scope, for `IO.syncStep` and nothing else.
    *
-   * `syncStep` runs an `IO` on the calling thread as far as it can and hands back the rest as an
-   * `IO`. When the `Sync` it steps into reports an `Uncancelable` root scope, as `SyncIO`'s own
-   * instance does, `syncStep` steps inside `uncancelable` regions (masked regions, in cats-effect
-   * terms) and past `onCancel` finalizers, since neither can matter to a target that is never
-   * cancelled. What it hands back is then the inside of such a region, without the `uncancelable`
-   * around it and without the finalizers. Cancelling that, which is what a timeout does, skips the
-   * finalizers.
+   * `syncStep` runs an `IO` on the calling thread as far as it can and returns the rest as an `IO`.
+   * With an `Uncancelable` root scope, which `SyncIO`'s own instance reports, it steps inside
+   * `uncancelable` regions and past `onCancel` finalizers. The `IO` it returns has lost both, and a
+   * timeout that cancels it skips the finalizers. Under this instance `syncStep` stops in front of
+   * `uncancelable` and `onCancel` and returns the region whole.
    *
-   * Under this instance `syncStep` stops in front of `uncancelable` and `onCancel` instead, and
-   * hands back the region whole.
-   *
-   * `rootCancelScope` is the only member `syncStep` reads to make that choice. Every other member
-   * is here to satisfy `Sync` and delegates to `SyncIO`'s own instance. The instance is unlawful,
-   * because `SyncIO#canceled` does nothing and an instance calling `SyncIO` cancelable therefore
-   * breaks the `MonadCancel` laws, so it stays private and is never implicit.
+   * `rootCancelScope` is the only member `syncStep` reads for that; the others delegate to
+   * `SyncIO`'s own instance. Reporting `SyncIO` as cancelable is false, since `SyncIO#canceled`
+   * does nothing, so the instance is unlawful, private and never implicit.
    *
    * @see
    *   [[https://typelevel.org/cats-effect/docs/typeclasses/monadcancel MonadCancel]] for masked

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
@@ -35,7 +35,7 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
 
   test("a 100k-deep flatMap chain over Ref.update steps to completion without a fiber") {
     val effect = IO.ref(0).flatMap { ref =>
-      (1 to 100000).foldLeft(IO.unit)((acc, _) => acc.flatMap(_ => ref.update(_ + 1))) *> ref.modify(n => (n, n))
+      (1 to 100_000).foldLeft(IO.unit)((acc, _) => acc.flatMap(_ => ref.update(_ + 1))) *> ref.modify(n => (n, n))
     }
 
     toTryNoRuntime(effect) shouldEqual Success(100000)

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
@@ -12,11 +12,9 @@ import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success}
 
 /**
- * Tests that `ioToTry` runs simple effects on the calling thread (no fiber, no runtime) and hands
- * everything else to the runtime. The runtime here rejects fibers, so submitting one fails the
- * conversion immediately.
- *
- * What the timeout does to the fiber part is in [[ToTryTimeoutSpec]].
+ * `ioToTry` runs simple effects on the calling thread and everything else as a fiber. The runtime
+ * here rejects fibers, so submitting one fails the conversion. [[ToTryTimeoutSpec]] covers the
+ * timeout behaviour of the fiber part.
  */
 class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
 
@@ -31,15 +29,15 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
 
   test("a 100k-deep flatMap chain over Ref.update steps to completion without a fiber") {
     val effect = IO.ref(0).flatMap { ref =>
-      (1 to 100_000).foldLeft(IO.unit)((acc, _) => acc.flatMap(_ => ref.update(_ + 1))) *> ref.modify(n => (n, n))
+      (1 to 100_000).foldLeft(IO.unit)((acc, _) => acc.flatMap(_ => ref.update(_ + 1))) *> ref.get
     }
 
     toTry(effect) shouldEqual Success(100_000)
   }
 
-  // `true`: shapes a per-record codec or deserializer runs, must stay on the calling thread.
-  // `false`: shapes the step must not enter (doing so would drop the uncancelable region and its
-  // finalizers). The fiber submission proves it stopped in front of them instead.
+  // `true`: per-record shapes (codecs, deserializers) that must stay on the calling thread.
+  // `false`: shapes the step must not enter because doing so drops protections. A fiber submission
+  // proves it stopped in front of them.
   for {
     (name, effect, callingThread) <- List(
       ("Ref#update", IO.ref(0).flatMap(_.update(_ + 1)), true),

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
@@ -38,7 +38,7 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
       (1 to 100_000).foldLeft(IO.unit)((acc, _) => acc.flatMap(_ => ref.update(_ + 1))) *> ref.modify(n => (n, n))
     }
 
-    toTryNoRuntime(effect) shouldEqual Success(100000)
+    toTryNoRuntime(effect) shouldEqual Success(100_000)
   }
 
   for {

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
@@ -35,9 +35,9 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
     toTry(effect) shouldEqual Success(100_000)
   }
 
-  // `true`: per-record shapes (codecs, deserializers) that must stay on the calling thread.
-  // `false`: shapes the step must not enter because doing so drops protections. A fiber submission
-  // proves it stopped in front of them.
+  // callingThread = true: per-record shapes (codecs, deserializers) that must stay on the calling thread.
+  // callingThread = false: shapes that syncStep must not walk into, because doing so strips the
+  // uncancelable region and its finalizers. The fiber submission proves syncStep stopped before them.
   for {
     (name, effect, callingThread) <- List(
       ("Ref#update", IO.ref(0).flatMap(_.update(_ + 1)), true),

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
@@ -6,31 +6,27 @@ import com.evolutiongaming.catshelper.IOSuite._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success}
 
 /**
- * Pins where `ioToTry` runs an effect: pure and `delay`-shaped effects inline on the calling
- * thread, everything else as a fiber under `IO.timeout`, and that the timeout honours masks and
- * brackets. The inline path is asserted against a runtime whose executors throw on `execute`, so
- * any fiber submission fails the conversion.
+ * Pins where `ioToTry` runs an effect: a pure or `delay`-shaped effect on the calling thread,
+ * everything else as a fiber. The calling-thread cases are asserted against a runtime whose
+ * executors throw instead of running a fiber, so submitting one fails the conversion and cannot
+ * pass unnoticed.
+ *
+ * What the timeout then does to the fiber is [[ToTryTimeoutSpec]].
  */
 class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
 
-  private val timeout = 100.millis
-
-  private val toTry = ToTry.ioToTry(timeout)
-
-  private val toTryNoRuntime = ToTry.ioToTry(timeout)(poisoned)
+  private val toTry = ToTry.ioToTry(100.millis)(runtimeRejectingFibers)
 
   test("pure and delay-shaped effects never touch the runtime") {
     val effect = IO.pure(1).map(_ + 1).flatMap(x => IO(x * 2)).handleErrorWith(_ => IO.pure(-1))
 
-    toTryNoRuntime(effect) shouldEqual Success(4)
+    toTry(effect) shouldEqual Success(4)
   }
 
   test("a 100k-deep flatMap chain over Ref.update steps to completion without a fiber") {
@@ -38,11 +34,15 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
       (1 to 100_000).foldLeft(IO.unit)((acc, _) => acc.flatMap(_ => ref.update(_ + 1))) *> ref.modify(n => (n, n))
     }
 
-    toTryNoRuntime(effect) shouldEqual Success(100_000)
+    toTry(effect) shouldEqual Success(100_000)
   }
 
+  // The `true` shapes are what a per-record conversion runs, a codec or a deserializer, and they
+  // have to stay on the calling thread. The `false` shapes are the ones the step must not enter:
+  // entering them is what dropped the mask and the finalizers, so reaching the runtime is the
+  // evidence that the step stopped in front of them instead.
   for {
-    (name, effect, inline) <- List(
+    (name, effect, callingThread) <- List(
       ("Ref#update", IO.ref(0).flatMap(_.update(_ + 1)), true),
       ("Deferred#complete", IO.deferred[Int].flatMap(_.complete(1).void), true),
       ("uncancelable", IO.unit.uncancelable, false),
@@ -50,46 +50,23 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
       ("Resource.allocated", Resource.make(IO.unit)(_ => IO.unit).allocated.void, false),
     )
   } {
-    test(s"$name ${ if (inline) "runs inline" else "goes through the runtime" }") {
-      val expected = if (inline) Success(()) else Failure(RuntimeTouched)
+    test(s"$name ${ if (callingThread) "runs on the calling thread" else "goes through the runtime" }") {
+      val expected = if (callingThread) Success(()) else Failure(FiberSubmitted)
 
-      toTryNoRuntime(effect) shouldEqual expected
+      toTry(effect) shouldEqual expected
     }
   }
 
-  test("the timeout waits inside an uncancelable region") {
-    val cancelled = new AtomicBoolean(false)
-    val finished = new AtomicBoolean(false)
-    val body = IO.sleep(300.millis).onCancel(IO(cancelled.set(true))) *> IO(finished.set(true))
-    val started = System.nanoTime()
+  private object FiberSubmitted extends RuntimeException("a fiber was submitted to the runtime") with NoStackTrace
 
-    toTry(body.uncancelable) shouldEqual Success(())
-
-    (System.nanoTime() - started).nanos should be >= 300.millis
-    finished.get() shouldBe true
-    cancelled.get() shouldBe false
-  }
-
-  test("the timeout releases a resource acquired before the async boundary") {
-    val acquired = new AtomicBoolean(false)
-    val released = new AtomicBoolean(false)
-    val effect = Resource
-      .make(IO(acquired.set(true)))(_ => IO(released.set(true)))
-      .use(_ => IO.sleep(10.seconds))
-
-    toTry(effect) should matchPattern { case Failure(_: TimeoutException) => }
-
-    acquired.get() shouldBe true
-    released.get() shouldBe true
-  }
-
-  private object RuntimeTouched extends RuntimeException("IORuntime was touched") with NoStackTrace
-
-  private def poisoned: IORuntime = {
-    val throwing = new ExecutionContext {
-      def execute(runnable: Runnable): Unit = throw RuntimeTouched
+  /**
+   * Runs nothing: every fiber submission throws [[FiberSubmitted]] out of the conversion.
+   */
+  private def runtimeRejectingFibers: IORuntime = {
+    val rejecting = new ExecutionContext {
+      def execute(runnable: Runnable): Unit = throw FiberSubmitted
       def reportFailure(cause: Throwable): Unit = ()
     }
-    IORuntime(throwing, throwing, ioRuntime.scheduler, () => (), IORuntimeConfig())
+    IORuntime(rejecting, rejecting, ioRuntime.scheduler, () => (), IORuntimeConfig())
   }
 }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
@@ -1,0 +1,95 @@
+package com.evolutiongaming.catshelper
+
+import cats.effect.unsafe.{IORuntime, IORuntimeConfig}
+import cats.effect.{IO, Resource}
+import com.evolutiongaming.catshelper.IOSuite._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.util.control.NoStackTrace
+import scala.util.{Failure, Success}
+
+/**
+ * Pins where `ioToTry` runs an effect: pure and `delay`-shaped effects inline on the calling
+ * thread, everything else as a fiber under `IO.timeout`, and that the timeout honours masks and
+ * brackets. The inline path is asserted against a runtime whose executors throw on `execute`, so
+ * any fiber submission fails the conversion.
+ */
+class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
+
+  private val timeout = 100.millis
+
+  private val toTry = ToTry.ioToTry(timeout)
+
+  private val toTryNoRuntime = ToTry.ioToTry(timeout)(poisoned)
+
+  test("pure and delay-shaped effects never touch the runtime") {
+    val effect = IO.pure(1).map(_ + 1).flatMap(x => IO(x * 2)).handleErrorWith(_ => IO.pure(-1))
+
+    toTryNoRuntime(effect) shouldEqual Success(4)
+  }
+
+  test("a 100k-deep flatMap chain over Ref.update steps to completion without a fiber") {
+    val effect = IO.ref(0).flatMap { ref =>
+      (1 to 100000).foldLeft(IO.unit)((acc, _) => acc.flatMap(_ => ref.update(_ + 1))) *> ref.modify(n => (n, n))
+    }
+
+    toTryNoRuntime(effect) shouldEqual Success(100000)
+  }
+
+  for {
+    (name, effect, inline) <- List(
+      ("Ref#update", IO.ref(0).flatMap(_.update(_ + 1)), true),
+      ("Deferred#complete", IO.deferred[Int].flatMap(_.complete(1).void), true),
+      ("uncancelable", IO.unit.uncancelable, false),
+      ("onCancel", IO.unit.onCancel(IO.unit), false),
+      ("Resource.allocated", Resource.make(IO.unit)(_ => IO.unit).allocated.void, false),
+    )
+  } {
+    test(s"$name ${ if (inline) "runs inline" else "goes through the runtime" }") {
+      val expected = if (inline) Success(()) else Failure(RuntimeTouched)
+
+      toTryNoRuntime(effect) shouldEqual expected
+    }
+  }
+
+  test("the timeout waits inside an uncancelable region") {
+    val cancelled = new AtomicBoolean(false)
+    val finished = new AtomicBoolean(false)
+    val body = IO.sleep(300.millis).onCancel(IO(cancelled.set(true))) *> IO(finished.set(true))
+    val started = System.nanoTime()
+
+    toTry(body.uncancelable) shouldEqual Success(())
+
+    (System.nanoTime() - started).nanos should be >= 300.millis
+    finished.get() shouldBe true
+    cancelled.get() shouldBe false
+  }
+
+  test("the timeout releases a resource acquired before the async boundary") {
+    val acquired = new AtomicBoolean(false)
+    val released = new AtomicBoolean(false)
+    val effect = Resource
+      .make(IO(acquired.set(true)))(_ => IO(released.set(true)))
+      .use(_ => IO.sleep(10.seconds))
+
+    toTry(effect) should matchPattern { case Failure(_: TimeoutException) => }
+
+    acquired.get() shouldBe true
+    released.get() shouldBe true
+  }
+
+  private object RuntimeTouched extends RuntimeException("IORuntime was touched") with NoStackTrace
+
+  private def poisoned: IORuntime = {
+    val throwing = new ExecutionContext {
+      def execute(runnable: Runnable): Unit = throw RuntimeTouched
+      def reportFailure(cause: Throwable): Unit = ()
+    }
+    IORuntime(throwing, throwing, ioRuntime.scheduler, () => (), IORuntimeConfig())
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
@@ -12,16 +12,16 @@ import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success}
 
 /**
- * Pins where `ioToTry` runs an effect: a pure or `delay`-shaped effect on the calling thread,
- * everything else as a fiber. The calling-thread cases are asserted against a runtime whose
- * executors throw instead of running a fiber, so submitting one fails the conversion and cannot
- * pass unnoticed.
+ * Pins where `ioToTry` runs an effect: pure and `delay`-shaped ones on the calling thread,
+ * everything else as a fiber. The runtime used here throws instead of running a fiber, so a
+ * conversion that submits one fails the test.
  *
- * What the timeout then does to the fiber is [[ToTryTimeoutSpec]].
+ * [[ToTryTimeoutSpec]] covers what the timeout does to the fiber.
  */
 class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
 
-  private val toTry = ToTry.ioToTry(100.millis)(runtimeRejectingFibers)
+  // the timeout is never reached here: a fiber submission fails at once
+  private val toTry = ToTry.ioToTry(1.minute)(runtimeRejectingFibers)
 
   test("pure and delay-shaped effects never touch the runtime") {
     val effect = IO.pure(1).map(_ + 1).flatMap(x => IO(x * 2)).handleErrorWith(_ => IO.pure(-1))
@@ -37,10 +37,9 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
     toTry(effect) shouldEqual Success(100_000)
   }
 
-  // The `true` shapes are what a per-record conversion runs, a codec or a deserializer, and they
-  // have to stay on the calling thread. The `false` shapes are the ones the step must not enter:
-  // entering them is what dropped the mask and the finalizers, so reaching the runtime is the
-  // evidence that the step stopped in front of them instead.
+  // `true` shapes are what a per-record codec or deserializer runs; they must stay on the calling
+  // thread. `false` shapes are what the step must not enter, because entering them drops the mask
+  // and the finalizers. Reaching the runtime proves it stopped in front of them.
   for {
     (name, effect, callingThread) <- List(
       ("Ref#update", IO.ref(0).flatMap(_.update(_ + 1)), true),
@@ -60,7 +59,7 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
   private object FiberSubmitted extends RuntimeException("a fiber was submitted to the runtime") with NoStackTrace
 
   /**
-   * Runs nothing: every fiber submission throws [[FiberSubmitted]] out of the conversion.
+   * Runs nothing: a fiber submission throws [[FiberSubmitted]], which becomes the result.
    */
   private def runtimeRejectingFibers: IORuntime = {
     val rejecting = new ExecutionContext {

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTrySyncStepSpec.scala
@@ -12,15 +12,15 @@ import scala.util.control.NoStackTrace
 import scala.util.{Failure, Success}
 
 /**
- * Pins where `ioToTry` runs an effect: pure and `delay`-shaped ones on the calling thread,
- * everything else as a fiber. The runtime used here throws instead of running a fiber, so a
- * conversion that submits one fails the test.
+ * Tests that `ioToTry` runs simple effects on the calling thread (no fiber, no runtime) and hands
+ * everything else to the runtime. The runtime here rejects fibers, so submitting one fails the
+ * conversion immediately.
  *
- * [[ToTryTimeoutSpec]] covers what the timeout does to the fiber.
+ * What the timeout does to the fiber part is in [[ToTryTimeoutSpec]].
  */
 class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
 
-  // the timeout is never reached here: a fiber submission fails at once
+  // the timeout is never reached: a fiber submission fails before it could matter
   private val toTry = ToTry.ioToTry(1.minute)(runtimeRejectingFibers)
 
   test("pure and delay-shaped effects never touch the runtime") {
@@ -37,9 +37,9 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
     toTry(effect) shouldEqual Success(100_000)
   }
 
-  // `true` shapes are what a per-record codec or deserializer runs; they must stay on the calling
-  // thread. `false` shapes are what the step must not enter, because entering them drops the mask
-  // and the finalizers. Reaching the runtime proves it stopped in front of them.
+  // `true`: shapes a per-record codec or deserializer runs, must stay on the calling thread.
+  // `false`: shapes the step must not enter (doing so would drop the uncancelable region and its
+  // finalizers). The fiber submission proves it stopped in front of them instead.
   for {
     (name, effect, callingThread) <- List(
       ("Ref#update", IO.ref(0).flatMap(_.update(_ + 1)), true),
@@ -59,7 +59,7 @@ class ToTrySyncStepSpec extends AnyFunSuite with Matchers {
   private object FiberSubmitted extends RuntimeException("a fiber was submitted to the runtime") with NoStackTrace
 
   /**
-   * Runs nothing: a fiber submission throws [[FiberSubmitted]], which becomes the result.
+   * A runtime that runs nothing: submitting a fiber throws [[FiberSubmitted]].
    */
   private def runtimeRejectingFibers: IORuntime = {
     val rejecting = new ExecutionContext {

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
@@ -12,26 +12,23 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 /**
- * `skafka` runs a Kafka rebalance callback through `ToTry[IO]`, so the effect has to finish on the
- * poll thread within the ambient `ioToTry(1.minute)`. `kafka-flow` recovers a partition inside such
- * a callback and holds a semaphore permit for the whole recovery, as
- * `semaphore.permit.use { ... }.uncancelable`, so that a half-done recovery cannot leave the flow
- * inconsistent.
+ * `skafka` runs a Kafka rebalance callback through `ToTry[IO]`, and `kafka-flow` recovers a
+ * partition inside one, holding a semaphore permit across the recovery as
+ * `semaphore.permit.use { ... }.uncancelable`.
  *
- * The previous `ioToTry` stepped inside that `uncancelable` and past the finalizers, then cancelled
- * what was left when the timeout fired. The permit was never given back, so every later call on the
- * flow blocked on the semaphore and the consumer stopped processing without failing anything
- * (kafka-flow#937). Every test below fails against that implementation.
+ * These tests pin what a timeout does to that shape: finalizers run, the permit comes back, and a
+ * masked recovery is left to finish. The previous `ioToTry` gave none of the three and left the
+ * flow blocked on its own semaphore (kafka-flow#937), so every test below fails against it.
  */
 class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
 
   // longer than `ToTry` waits; a passing run never reaches it
   private val slowRecovery = 1.minute
 
-  test("a timeout releases what the effect acquired, and gives the permit back") {
+  test("a timeout releases what the effect acquired and gives the permit back") {
     val guard = Semaphore[IO](1).unsafeRunSync()
     val released = new AtomicBoolean(false)
-    // the permit is taken on the calling thread, the state rebuild sleeps past the timeout
+    // the permit is taken on the calling thread; the state rebuild then sleeps past the timeout
     val recovery = guard.permit.use { _ =>
       Resource.onFinalize(IO(released.set(true))).use(_ => IO.sleep(slowRecovery))
     }
@@ -58,7 +55,7 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
     val guard = Semaphore[IO](1).unsafeRunSync()
     val cancelled = new AtomicBoolean(false)
     // `kafka-flow` guards `add`, `apply` and its own release with one permit, taken inside
-    // `uncancelable`: a permit lost to cancellation would block all three forever
+    // `uncancelable`: a permit lost to cancellation would block all three
     val recovery = guard
       .permit
       .use(_ => IO.sleep(200.millis).onCancel(IO(cancelled.set(true))))
@@ -70,12 +67,11 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
     guard.available.unsafeRunSync() shouldEqual 1L
   }
 
-  test("nested masks: a timeout reaches a polled region and gives the permit back") {
+  test("nested uncancelable: a timeout reaches a polled region and the permit comes back") {
     val guard = Semaphore[IO](1).unsafeRunSync()
     val cancelled = new AtomicBoolean(false)
     // the sleep sits under two `uncancelable`, both polled, so it stays cancelable. The step stops
-    // at the outermost one and hands the whole block over, nesting included; `IO.timeout` then
-    // follows cats-effect's ordinary rules for it
+    // at the outermost one and returns the whole nest, which `IO.timeout` treats like any other `IO`
     val recovery = guard.permit.use { _ =>
       IO.uncancelable { outer =>
         outer(IO.uncancelable(inner => inner(IO.sleep(slowRecovery).onCancel(IO(cancelled.set(true))))))

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
@@ -1,0 +1,101 @@
+package com.evolutiongaming.catshelper
+
+import cats.effect.std.Semaphore
+import cats.effect.{IO, Resource}
+import com.evolutiongaming.catshelper.IOSuite._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicReference
+import scala.concurrent.duration._
+import scala.util.{Failure, Success}
+
+/**
+ * `ToTry[IO]` is how `skafka` bridges Kafka's rebalance callback: the IO runs to completion on the
+ * poll thread, bounded by `ioToTry(1.minute)`.
+ *
+ * `kafka-flow` runs partition recovery through that bridge: resource-shaped work guarded by a
+ * semaphore permit inside `.uncancelable`. The previous `ioToTry` stepped through `.uncancelable`
+ * and `onCancel` before handing the remainder to `unsafeRunTimed`, which cancelled it on timeout
+ * without waiting: the permit was never released and every subsequent poll blocked on the
+ * semaphore. The consumer silently stopped processing.
+ *
+ * All three specs fail against the previous `ioToTry` and pass with the cooperative timeout.
+ */
+class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
+
+  private val defaultTimeout = 200.millis
+
+  // longer than any test waits; a passing run never reaches it
+  private val slowRecovery = 10.seconds
+
+  test("timeout releases a resource acquired before the async boundary") {
+    val f = fixture()
+
+    f.toTry(f.recovery) should matchPattern { case Failure(_: TimeoutException) => }
+
+    f.recorded shouldEqual Vector("acquired", "released")
+  }
+
+  test("a timed-out attempt does not strand the guard it acquired") {
+    val f = fixture()
+
+    f.toTry(f.recovery) should matchPattern { case Failure(_: TimeoutException) => }
+
+    // what a retry around the flow does next
+    f.toTry(f.recovery) should matchPattern { case Failure(_: TimeoutException) => }
+
+    f.recorded shouldEqual Vector("acquired", "released", "acquired", "released")
+  }
+
+  test("an uncancelable guarded recovery completes and releases its guard") {
+    val f = fixture(timeout = 100.millis, recoveryDuration = 300.millis)
+
+    // `TopicFlow` guards `add`, `apply` and its own release with one permit, taken inside
+    // `uncancelable`: a permit lost to cancellation would block all three forever
+    f.toTry(f.guardedRecovery) shouldEqual Success(())
+    f.toTry(f.guardedRecovery) shouldEqual Success(())
+
+    f.recorded shouldEqual Vector("acquired", "released", "acquired", "released")
+  }
+
+  private def fixture(
+    timeout: FiniteDuration = defaultTimeout,
+    recoveryDuration: FiniteDuration = slowRecovery,
+  ): Fixture =
+    new Fixture(
+      toTry = ToTry.ioToTry(timeout),
+      guard = Semaphore[IO](1).unsafeRunSync(),
+      log = new AtomicReference(Vector.empty[String]),
+      recoveryDuration = recoveryDuration,
+    )
+
+  /**
+   * `guard` stands in for `TopicFlow`'s semaphore: the permit that must survive a timeout.
+   * `recoveryDuration` is how long the recovery body runs past the async boundary.
+   */
+  private class Fixture(
+    val toTry: ToTry[IO],
+    guard: Semaphore[IO],
+    log: AtomicReference[Vector[String]],
+    recoveryDuration: FiniteDuration,
+  ) {
+
+    def recorded: Vector[String] = log.get()
+
+    /**
+     * Mimics `PartitionFlow`: take the guard and finish the acquire synchronously, then rebuild
+     * state across an asynchronous boundary. The release gives the guard back.
+     */
+    def recovery: IO[Unit] =
+      Resource
+        .make(guard.acquire *> record("acquired"))(_ => record("released") *> guard.release)
+        .use(_ => IO.sleep(recoveryDuration))
+
+    // wrapped the way `TopicFlow` wraps it, so the permit cannot be lost to cancellation
+    def guardedRecovery: IO[Unit] = recovery.uncancelable
+
+    private def record(event: String): IO[Unit] = IO(log.updateAndGet(_ :+ event)).void
+  }
+}

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
@@ -1,13 +1,12 @@
 package com.evolutiongaming.catshelper
 
 import cats.effect.std.Semaphore
-import cats.effect.{IO, Resource}
+import cats.effect.{IO, Ref, Resource}
 import com.evolutiongaming.catshelper.IOSuite._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicBoolean
+import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
@@ -19,6 +18,10 @@ import scala.util.{Failure, Success}
  * These tests pin what a timeout does to that shape: finalizers run, the permit comes back, and a
  * masked recovery is left to finish. The previous `ioToTry` gave none of the three and left the
  * flow blocked on its own semaphore (kafka-flow#937), so every test below fails against it.
+ *
+ * The conversion blocks the thread it is called on, so each test hands it to `IO.blocking`, as
+ * `skafka` does on the poll thread. Its own timing is real: a clock outside it would not govern the
+ * effect it runs on the ambient runtime.
  */
 class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
 
@@ -26,61 +29,81 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
   private val slowRecovery = 1.minute
 
   test("a timeout releases what the effect acquired and gives the permit back") {
-    val guard = Semaphore[IO](1).unsafeRunSync()
-    val released = new AtomicBoolean(false)
-    // the permit is taken on the calling thread; the state rebuild then sleeps past the timeout
-    val recovery = guard.permit.use { _ =>
-      Resource.onFinalize(IO(released.set(true))).use(_ => IO.sleep(slowRecovery))
+    val io = for {
+      guard <- Semaphore[IO](1)
+      released <- Ref[IO].of(false)
+      // the permit is taken on the calling thread; the state rebuild then sleeps past the timeout
+      recovery = guard.permit.use { _ =>
+        Resource.onFinalize(released.set(true)).use(_ => IO.sleep(slowRecovery))
+      }
+      outcome <- IO.blocking { ToTry.ioToTry(50.millis).apply(recovery) }
+      wasReleased <- released.get
+      permits <- guard.available
+    } yield {
+      outcome should matchPattern { case Failure(_: TimeoutException) => }
+      wasReleased shouldBe true
+      permits shouldEqual 1L
     }
-
-    ToTry.ioToTry(50.millis).apply(recovery) should matchPattern { case Failure(_: TimeoutException) => }
-
-    released.get() shouldBe true
-    guard.available.unsafeRunSync() shouldEqual 1L
+    io.unsafeRunSync()
   }
 
   test("a retry after a timed-out attempt can take the permit again") {
-    val guard = Semaphore[IO](1).unsafeRunSync()
-    val toTry = ToTry.ioToTry(50.millis)
-    val recovery = guard.permit.use(_ => IO.sleep(slowRecovery))
-
-    toTry(recovery) should matchPattern { case Failure(_: TimeoutException) => }
-    // what a retry around the flow does next
-    toTry(recovery) should matchPattern { case Failure(_: TimeoutException) => }
-
-    guard.available.unsafeRunSync() shouldEqual 1L
+    val io = for {
+      guard <- Semaphore[IO](1)
+      toTry = ToTry.ioToTry(50.millis)
+      recovery = guard.permit.use(_ => IO.sleep(slowRecovery))
+      first <- IO.blocking { toTry(recovery) }
+      // what a retry around the flow does next
+      second <- IO.blocking { toTry(recovery) }
+      permits <- guard.available
+    } yield {
+      first should matchPattern { case Failure(_: TimeoutException) => }
+      second should matchPattern { case Failure(_: TimeoutException) => }
+      permits shouldEqual 1L
+    }
+    io.unsafeRunSync()
   }
 
   test("an uncancelable guarded recovery runs past the timeout and gives the permit back") {
-    val guard = Semaphore[IO](1).unsafeRunSync()
-    val cancelled = new AtomicBoolean(false)
-    // `kafka-flow` guards `add`, `apply` and its own release with one permit, taken inside
-    // `uncancelable`: a permit lost to cancellation would block all three
-    val recovery = guard
-      .permit
-      .use(_ => IO.sleep(200.millis).onCancel(IO(cancelled.set(true))))
-      .uncancelable
-
-    ToTry.ioToTry(50.millis).apply(recovery) shouldEqual Success(())
-
-    cancelled.get() shouldBe false
-    guard.available.unsafeRunSync() shouldEqual 1L
+    val io = for {
+      guard <- Semaphore[IO](1)
+      cancelled <- Ref[IO].of(false)
+      // `kafka-flow` guards `add`, `apply` and its own release with one permit, taken inside
+      // `uncancelable`: a permit lost to cancellation would block all three
+      recovery = guard
+        .permit
+        .use(_ => IO.sleep(200.millis).onCancel(cancelled.set(true)))
+        .uncancelable
+      outcome <- IO.blocking { ToTry.ioToTry(50.millis).apply(recovery) }
+      wasCancelled <- cancelled.get
+      permits <- guard.available
+    } yield {
+      outcome shouldEqual Success(())
+      wasCancelled shouldBe false
+      permits shouldEqual 1L
+    }
+    io.unsafeRunSync()
   }
 
   test("nested uncancelable: a timeout reaches a polled region and the permit comes back") {
-    val guard = Semaphore[IO](1).unsafeRunSync()
-    val cancelled = new AtomicBoolean(false)
-    // the sleep sits under two `uncancelable`, both polled, so it stays cancelable. The step stops
-    // at the outermost one and returns the whole nest, which `IO.timeout` treats like any other `IO`
-    val recovery = guard.permit.use { _ =>
-      IO.uncancelable { outer =>
-        outer(IO.uncancelable(inner => inner(IO.sleep(slowRecovery).onCancel(IO(cancelled.set(true))))))
+    val io = for {
+      guard <- Semaphore[IO](1)
+      cancelled <- Ref[IO].of(false)
+      // the sleep sits under two `uncancelable`, both polled, so it stays cancelable. The step stops
+      // at the outermost one and returns the whole nest, which `IO.timeout` treats like any other `IO`
+      recovery = guard.permit.use { _ =>
+        IO.uncancelable { outer =>
+          outer(IO.uncancelable(inner => inner(IO.sleep(slowRecovery).onCancel(cancelled.set(true)))))
+        }
       }
+      outcome <- IO.blocking { ToTry.ioToTry(50.millis).apply(recovery) }
+      wasCancelled <- cancelled.get
+      permits <- guard.available
+    } yield {
+      outcome should matchPattern { case Failure(_: TimeoutException) => }
+      wasCancelled shouldBe true
+      permits shouldEqual 1L
     }
-
-    ToTry.ioToTry(50.millis).apply(recovery) should matchPattern { case Failure(_: TimeoutException) => }
-
-    cancelled.get() shouldBe true
-    guard.available.unsafeRunSync() shouldEqual 1L
+    io.unsafeRunSync()
   }
 }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
@@ -83,7 +83,9 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
       // two uncancelable, both polled: the sleep stays cancelable
       recovery = guard.permit.use { _ =>
         IO.uncancelable { outer =>
-          outer(IO.uncancelable(inner => inner(IO.sleep(slowRecovery).onCancel(cancelled.set(true)))))
+          outer(IO.uncancelable { inner =>
+            inner(IO.sleep(slowRecovery).onCancel(cancelled.set(true)))
+          })
         }
       }
       outcome <- IO.blocking { ToTry.ioToTry(50.millis).apply(recovery) }

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
@@ -12,11 +12,9 @@ import scala.util.{Failure, Success}
 
 /**
  * `skafka` runs a Kafka rebalance callback through `ToTry[IO]`, and `kafka-flow` holds a semaphore
- * permit across its partition recovery as `semaphore.permit.use { ... }.uncancelable`.
- *
- * These tests pin three properties of a timeout against that shape: finalizers run, the permit
- * comes back, and an uncancelable recovery is left to finish. The previous `ioToTry` gave none of
- * the three (kafka-flow#937), so every test fails against it.
+ * permit across its partition recovery as `semaphore.permit.use { ... }.uncancelable`. These tests
+ * pin that a timeout runs finalizers, gives the permit back, and waits for an uncancelable
+ * recovery. The previous `ioToTry` did none of the three (kafka-flow#937).
  */
 class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
 
@@ -30,6 +28,7 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
       recovery = guard.permit.use { _ =>
         Resource.onFinalize(released.set(true)).use(_ => IO.sleep(slowRecovery))
       }
+      // IO.blocking because the conversion blocks the calling thread, as skafka does on the poll thread
       outcome <- IO.blocking { ToTry.ioToTry(50.millis).apply(recovery) }
       wasReleased <- released.get
       permits <- guard.available
@@ -61,8 +60,7 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
     val io = for {
       guard <- Semaphore[IO](1)
       cancelled <- Ref[IO].of(false)
-      // the permit is taken inside `uncancelable`, as `kafka-flow` does it: a lost permit would
-      // block every later call on the flow
+      // permit inside `uncancelable`, as kafka-flow does it
       recovery = guard
         .permit
         .use(_ => IO.sleep(200.millis).onCancel(cancelled.set(true)))
@@ -82,8 +80,7 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
     val io = for {
       guard <- Semaphore[IO](1)
       cancelled <- Ref[IO].of(false)
-      // two `uncancelable`, both polled: the sleep stays cancelable. The step stops at the
-      // outermost one and returns the whole nest; `IO.timeout` handles the rest normally
+      // two uncancelable, both polled: the sleep stays cancelable
       recovery = guard.permit.use { _ =>
         IO.uncancelable { outer =>
           outer(IO.uncancelable(inner => inner(IO.sleep(slowRecovery).onCancel(cancelled.set(true)))))

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
@@ -11,17 +11,12 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 /**
- * `skafka` runs a Kafka rebalance callback through `ToTry[IO]`, and `kafka-flow` recovers a
- * partition inside one, holding a semaphore permit across the recovery as
- * `semaphore.permit.use { ... }.uncancelable`.
+ * `skafka` runs a Kafka rebalance callback through `ToTry[IO]`, and `kafka-flow` holds a semaphore
+ * permit across its partition recovery as `semaphore.permit.use { ... }.uncancelable`.
  *
- * These tests pin what a timeout does to that shape: finalizers run, the permit comes back, and a
- * masked recovery is left to finish. The previous `ioToTry` gave none of the three and left the
- * flow blocked on its own semaphore (kafka-flow#937), so every test below fails against it.
- *
- * The conversion blocks the thread it is called on, so each test hands it to `IO.blocking`, as
- * `skafka` does on the poll thread. Its own timing is real: a clock outside it would not govern the
- * effect it runs on the ambient runtime.
+ * These tests pin three properties of a timeout against that shape: finalizers run, the permit
+ * comes back, and an uncancelable recovery is left to finish. The previous `ioToTry` gave none of
+ * the three (kafka-flow#937), so every test fails against it.
  */
 class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
 
@@ -32,7 +27,6 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
     val io = for {
       guard <- Semaphore[IO](1)
       released <- Ref[IO].of(false)
-      // the permit is taken on the calling thread; the state rebuild then sleeps past the timeout
       recovery = guard.permit.use { _ =>
         Resource.onFinalize(released.set(true)).use(_ => IO.sleep(slowRecovery))
       }
@@ -53,7 +47,6 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
       toTry = ToTry.ioToTry(50.millis)
       recovery = guard.permit.use(_ => IO.sleep(slowRecovery))
       first <- IO.blocking { toTry(recovery) }
-      // what a retry around the flow does next
       second <- IO.blocking { toTry(recovery) }
       permits <- guard.available
     } yield {
@@ -68,8 +61,8 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
     val io = for {
       guard <- Semaphore[IO](1)
       cancelled <- Ref[IO].of(false)
-      // `kafka-flow` guards `add`, `apply` and its own release with one permit, taken inside
-      // `uncancelable`: a permit lost to cancellation would block all three
+      // the permit is taken inside `uncancelable`, as `kafka-flow` does it: a lost permit would
+      // block every later call on the flow
       recovery = guard
         .permit
         .use(_ => IO.sleep(200.millis).onCancel(cancelled.set(true)))
@@ -89,8 +82,8 @@ class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
     val io = for {
       guard <- Semaphore[IO](1)
       cancelled <- Ref[IO].of(false)
-      // the sleep sits under two `uncancelable`, both polled, so it stays cancelable. The step stops
-      // at the outermost one and returns the whole nest, which `IO.timeout` treats like any other `IO`
+      // two `uncancelable`, both polled: the sleep stays cancelable. The step stops at the
+      // outermost one and returns the whole nest; `IO.timeout` handles the rest normally
       recovery = guard.permit.use { _ =>
         IO.uncancelable { outer =>
           outer(IO.uncancelable(inner => inner(IO.sleep(slowRecovery).onCancel(cancelled.set(true)))))

--- a/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
+++ b/core/src/test/scala/com/evolutiongaming/catshelper/ToTryTimeoutSpec.scala
@@ -7,95 +7,84 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 /**
- * `ToTry[IO]` is how `skafka` bridges Kafka's rebalance callback: the IO runs to completion on the
- * poll thread, bounded by `ioToTry(1.minute)`.
+ * `skafka` runs a Kafka rebalance callback through `ToTry[IO]`, so the effect has to finish on the
+ * poll thread within the ambient `ioToTry(1.minute)`. `kafka-flow` recovers a partition inside such
+ * a callback and holds a semaphore permit for the whole recovery, as
+ * `semaphore.permit.use { ... }.uncancelable`, so that a half-done recovery cannot leave the flow
+ * inconsistent.
  *
- * `kafka-flow` runs partition recovery through that bridge: resource-shaped work guarded by a
- * semaphore permit inside `.uncancelable`. The previous `ioToTry` stepped through `.uncancelable`
- * and `onCancel` before handing the remainder to `unsafeRunTimed`, which cancelled it on timeout
- * without waiting: the permit was never released and every subsequent poll blocked on the
- * semaphore. The consumer silently stopped processing.
- *
- * All three specs fail against the previous `ioToTry` and pass with the cooperative timeout.
+ * The previous `ioToTry` stepped inside that `uncancelable` and past the finalizers, then cancelled
+ * what was left when the timeout fired. The permit was never given back, so every later call on the
+ * flow blocked on the semaphore and the consumer stopped processing without failing anything
+ * (kafka-flow#937). Every test below fails against that implementation.
  */
 class ToTryTimeoutSpec extends AnyFunSuite with Matchers {
 
-  private val defaultTimeout = 200.millis
+  // longer than `ToTry` waits; a passing run never reaches it
+  private val slowRecovery = 1.minute
 
-  // longer than any test waits; a passing run never reaches it
-  private val slowRecovery = 10.seconds
+  test("a timeout releases what the effect acquired, and gives the permit back") {
+    val guard = Semaphore[IO](1).unsafeRunSync()
+    val released = new AtomicBoolean(false)
+    // the permit is taken on the calling thread, the state rebuild sleeps past the timeout
+    val recovery = guard.permit.use { _ =>
+      Resource.onFinalize(IO(released.set(true))).use(_ => IO.sleep(slowRecovery))
+    }
 
-  test("timeout releases a resource acquired before the async boundary") {
-    val f = fixture()
+    ToTry.ioToTry(50.millis).apply(recovery) should matchPattern { case Failure(_: TimeoutException) => }
 
-    f.toTry(f.recovery) should matchPattern { case Failure(_: TimeoutException) => }
-
-    f.recorded shouldEqual Vector("acquired", "released")
+    released.get() shouldBe true
+    guard.available.unsafeRunSync() shouldEqual 1L
   }
 
-  test("a timed-out attempt does not strand the guard it acquired") {
-    val f = fixture()
+  test("a retry after a timed-out attempt can take the permit again") {
+    val guard = Semaphore[IO](1).unsafeRunSync()
+    val toTry = ToTry.ioToTry(50.millis)
+    val recovery = guard.permit.use(_ => IO.sleep(slowRecovery))
 
-    f.toTry(f.recovery) should matchPattern { case Failure(_: TimeoutException) => }
-
+    toTry(recovery) should matchPattern { case Failure(_: TimeoutException) => }
     // what a retry around the flow does next
-    f.toTry(f.recovery) should matchPattern { case Failure(_: TimeoutException) => }
+    toTry(recovery) should matchPattern { case Failure(_: TimeoutException) => }
 
-    f.recorded shouldEqual Vector("acquired", "released", "acquired", "released")
+    guard.available.unsafeRunSync() shouldEqual 1L
   }
 
-  test("an uncancelable guarded recovery completes and releases its guard") {
-    val f = fixture(timeout = 100.millis, recoveryDuration = 300.millis)
-
-    // `TopicFlow` guards `add`, `apply` and its own release with one permit, taken inside
+  test("an uncancelable guarded recovery runs past the timeout and gives the permit back") {
+    val guard = Semaphore[IO](1).unsafeRunSync()
+    val cancelled = new AtomicBoolean(false)
+    // `kafka-flow` guards `add`, `apply` and its own release with one permit, taken inside
     // `uncancelable`: a permit lost to cancellation would block all three forever
-    f.toTry(f.guardedRecovery) shouldEqual Success(())
-    f.toTry(f.guardedRecovery) shouldEqual Success(())
+    val recovery = guard
+      .permit
+      .use(_ => IO.sleep(200.millis).onCancel(IO(cancelled.set(true))))
+      .uncancelable
 
-    f.recorded shouldEqual Vector("acquired", "released", "acquired", "released")
+    ToTry.ioToTry(50.millis).apply(recovery) shouldEqual Success(())
+
+    cancelled.get() shouldBe false
+    guard.available.unsafeRunSync() shouldEqual 1L
   }
 
-  private def fixture(
-    timeout: FiniteDuration = defaultTimeout,
-    recoveryDuration: FiniteDuration = slowRecovery,
-  ): Fixture =
-    new Fixture(
-      toTry = ToTry.ioToTry(timeout),
-      guard = Semaphore[IO](1).unsafeRunSync(),
-      log = new AtomicReference(Vector.empty[String]),
-      recoveryDuration = recoveryDuration,
-    )
+  test("nested masks: a timeout reaches a polled region and gives the permit back") {
+    val guard = Semaphore[IO](1).unsafeRunSync()
+    val cancelled = new AtomicBoolean(false)
+    // the sleep sits under two `uncancelable`, both polled, so it stays cancelable. The step stops
+    // at the outermost one and hands the whole block over, nesting included; `IO.timeout` then
+    // follows cats-effect's ordinary rules for it
+    val recovery = guard.permit.use { _ =>
+      IO.uncancelable { outer =>
+        outer(IO.uncancelable(inner => inner(IO.sleep(slowRecovery).onCancel(IO(cancelled.set(true))))))
+      }
+    }
 
-  /**
-   * `guard` stands in for `TopicFlow`'s semaphore: the permit that must survive a timeout.
-   * `recoveryDuration` is how long the recovery body runs past the async boundary.
-   */
-  private class Fixture(
-    val toTry: ToTry[IO],
-    guard: Semaphore[IO],
-    log: AtomicReference[Vector[String]],
-    recoveryDuration: FiniteDuration,
-  ) {
+    ToTry.ioToTry(50.millis).apply(recovery) should matchPattern { case Failure(_: TimeoutException) => }
 
-    def recorded: Vector[String] = log.get()
-
-    /**
-     * Mimics `PartitionFlow`: take the guard and finish the acquire synchronously, then rebuild
-     * state across an asynchronous boundary. The release gives the guard back.
-     */
-    def recovery: IO[Unit] =
-      Resource
-        .make(guard.acquire *> record("acquired"))(_ => record("released") *> guard.release)
-        .use(_ => IO.sleep(recoveryDuration))
-
-    // wrapped the way `TopicFlow` wraps it, so the permit cannot be lost to cancellation
-    def guardedRecovery: IO[Unit] = recovery.uncancelable
-
-    private def record(event: String): IO[Unit] = IO(log.updateAndGet(_ :+ event)).void
+    cancelled.get() shouldBe true
+    guard.available.unsafeRunSync() shouldEqual 1L
   }
 }


### PR DESCRIPTION
Supersedes #330's work on `ioToTry` and incorporates #421's tests pinning down whether `Resource` finalizers (release) complete after a timeout.

The `StackOverflowException` behind evolution-gaming/skafka#477 was fixed upstream in cats-effect 3.6.2; it is pinned here by the 100k-deep chain test. Incidentally, #330 also fixes the `Resource` finalizer issue by removing `syncStep` entirely.

## Why

The main difference between master, #330 and this PR is that master and this PR use `syncStep`, while #330 does not.

Without `syncStep`, the whole effect runs through the Cats Effect runtime, adding the overhead of starting and synchronously waiting for a fiber even when the effect could complete synchronously.

Also, #330 makes synchronous effects subject to the timeout, while master and this PR avoid this.

## Unlawful `SyncIO`

The debatable complexity added by this PR is a custom `Sync` instance around `SyncIO`. It extends `Sync[SyncIO]`, only overriding `rootCancelScope` from `Uncancelable` to `Cancelable`.

Looking under the hood in cats-effect [here](https://github.com/typelevel/cats-effect/blob/v3.7.1/core/shared/src/main/scala/cats/effect/IO.scala#L2390-L2399) is where the `rootCancelScope` makes a difference:

```scala
case IO.Uncancelable(body, _) if G.rootCancelScope == CancelScope.Uncancelable =>
  // walk inside: unwrap the region, replace Poll with identity, keep going
  val ioa = body(new Poll[IO] { def apply[C](ioc: IO[C]): IO[C] = ioc })
  interpret(ioa, limit, stepsUntilDefer)

case IO.OnCancel(ioa, _) if G.rootCancelScope == CancelScope.Uncancelable =>
  // walk past: keep the effect, drop the finalizer
  interpret(ioa, limit, stepsUntilDefer)

case _ =>
  // stop: return the node as is
  G.pure(Left(io))
```

Because `Sync[SyncIO]` is `Uncancelable`, `syncStep` may step through `uncancelable`, `onCancel`, and `Resource` handling. If it later stops at an async boundary, the remaining `IO` may have lost its finalizers, so a timeout may skip the release entirely.

The custom instance reports itself as `Cancelable`, so `syncStep` falls through to `case _` at `Uncancelable` and `OnCancel` instead of entering them, and returns the remaining `IO` with its finalizers intact. It is unlawful because `SyncIO` cannot actually be cancelled, so it is kept private and used only to control where `syncStep` stops.

## Why `IO.timeout` instead of `unsafeRunTimed`

`ToTry` returns a `Try` the caller acts on immediately. `IO.timeout` guarantees that the effect is done (cancelled with finalizers run, or completed) before returning. `unsafeRunTimed` does not: it returns while the finalizer is still running on a detached fiber.

## Verdict

In short, we either accept the extra complexity of this PR or the added runtime overhead of #330, which also makes synchronous effects subject to the timeout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Pure and delay-based operations now execute synchronously when possible.
- Asynchronous operations have more reliable timeout and cancellation handling.
- Resources, permits, and cancellation guards are correctly released after timeouts.
- Timeout processing waits for required cleanup before completing, enabling safe recovery and retries.

## Tests

- Expanded coverage for synchronous execution, asynchronous boundaries, timeouts, cancellation, resource cleanup, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The leak this closes is described from the kafka-flow side in evolution-gaming/kafka-flow#937.
